### PR TITLE
Fix bug introduced with --reuse-account-lazy parameter

### DIFF
--- a/iapyx/src/backend/proxy/client.rs
+++ b/iapyx/src/backend/proxy/client.rs
@@ -56,9 +56,9 @@ pub enum Error {
         text: String,
     },
     #[error("could not send reqeuest")]
-    RequestError(#[from] reqwest::Error),
+    Request(#[from] reqwest::Error),
     #[error("server is not up")]
     ServerIsNotUp,
     #[error("Error code recieved: {0}")]
-    ErrorStatusCode(StatusCode),
+    StatusCode(StatusCode),
 }

--- a/iapyx/src/backend/proxy/server.rs
+++ b/iapyx/src/backend/proxy/server.rs
@@ -6,11 +6,11 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Malformed proxy address: {0}")]
-    MalformedProxyAddress(String),
+    Proxy(String),
     #[error("Malformed vit address: {0}")]
-    MalformedVitStationAddress(String),
+    VitStation(String),
     #[error("Malformed node rest address: {0}")]
-    MalformedNodeRestAddress(String),
+    NodeRest(String),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/iapyx/src/load/config/node.rs
+++ b/iapyx/src/load/config/node.rs
@@ -82,5 +82,5 @@ pub enum Error {
     #[error("cannot read folder {0:?}")]
     CannotReadQrs(PathBuf),
     #[error("multicontoller error")]
-    MultiControllerError(#[from] MultiControllerError),
+    MultiController(#[from] MultiControllerError),
 }

--- a/iapyx/src/load/multi_controller.rs
+++ b/iapyx/src/load/multi_controller.rs
@@ -138,8 +138,7 @@ impl MultiController {
         predicate: &dyn Fn(&Wallet) -> bool,
     ) {
         let wallet = self.wallets.get_mut(wallet_index).unwrap();
-
-        if predicate(&wallet) {
+        if predicate(wallet) {
             self.update_wallet_state(wallet_index)
         }
     }
@@ -227,11 +226,11 @@ impl Into<Vec<Wallet>> for MultiController {
 #[derive(Debug, Error)]
 pub enum MultiControllerError {
     #[error("wallet error")]
-    WalletError(#[from] crate::wallet::Error),
+    Wallet(#[from] crate::wallet::Error),
     #[error("wallet error")]
-    BackendError(#[from] crate::backend::WalletBackendError),
+    Backend(#[from] crate::backend::WalletBackendError),
     #[error("controller error")]
-    ControllerError(#[from] crate::ControllerError),
+    Controller(#[from] crate::ControllerError),
     #[error("pin read error")]
-    PinReadError(#[from] crate::qr::PinReadError),
+    PinRead(#[from] crate::qr::PinReadError),
 }

--- a/iapyx/src/load/multi_controller.rs
+++ b/iapyx/src/load/multi_controller.rs
@@ -132,6 +132,17 @@ impl MultiController {
         let account_state = backend.account_state(wallet.id()).unwrap();
         wallet.set_state((*account_state.value()).into(), account_state.counter());
     }
+    pub fn update_wallet_state_if(
+        &mut self,
+        wallet_index: usize,
+        predicate: &dyn Fn(&Wallet) -> bool,
+    ) {
+        let wallet = self.wallets.get_mut(wallet_index).unwrap();
+
+        if predicate(&wallet) {
+            self.update_wallet_state(wallet_index)
+        }
+    }
 
     pub fn vote(
         &mut self,

--- a/iapyx/src/load/request_generators/jormungandr/post/batch.rs
+++ b/iapyx/src/load/request_generators/jormungandr/post/batch.rs
@@ -1,5 +1,6 @@
 use crate::load::{MultiController, MultiControllerError};
 use crate::Proposal;
+use crate::Wallet;
 use jortestkit::load::{Id, Request, RequestFailure, RequestGenerator};
 use rand::RngCore;
 use rand_core::OsRng;
@@ -56,8 +57,13 @@ impl BatchWalletRequestGen {
             self.wallet_index
         };
 
+        // update state of wallet only before first vote.
+        // Then relay on mechanism of spending counter auto-update
         if self.update_account_before_vote {
-            self.multi_controller.update_wallet_state(wallet_index);
+            self.multi_controller
+                .update_wallet_state_if(wallet_index, &|wallet: &Wallet| {
+                    wallet.spending_counter() == 0
+                });
         }
 
         let batch_size = self.batch_size;

--- a/iapyx/src/load/request_generators/jormungandr/post/single.rs
+++ b/iapyx/src/load/request_generators/jormungandr/post/single.rs
@@ -55,7 +55,7 @@ impl WalletRequestGen {
 
         let proposal = self.proposals.choose(&mut self.rand).unwrap();
         let choice = Choice::new(*self.options.choose(&mut self.rand).unwrap());
-        self.multi_controller.vote(index, &proposal, choice)
+        self.multi_controller.vote(index, proposal, choice)
     }
 }
 

--- a/iapyx/src/load/request_generators/jormungandr/post/single.rs
+++ b/iapyx/src/load/request_generators/jormungandr/post/single.rs
@@ -1,5 +1,6 @@
 use crate::load::{MultiController, MultiControllerError};
 use crate::Proposal;
+use crate::Wallet;
 use chain_impl_mockchain::fragment::FragmentId;
 use jortestkit::load::{Request, RequestFailure, RequestGenerator};
 use rand::seq::SliceRandom;
@@ -45,8 +46,11 @@ impl WalletRequestGen {
             self.wallet_index
         };
 
+        // update state of wallet only before first vote.
+        // Then relay on mechanism of spending counter auto-update
         if self.update_account_before_vote {
-            self.multi_controller.update_wallet_state(index);
+            self.multi_controller
+                .update_wallet_state_if(index, &|wallet: &Wallet| wallet.spending_counter() == 0);
         }
 
         let proposal = self.proposals.choose(&mut self.rand).unwrap();

--- a/iapyx/src/load/scenario/artificial_users.rs
+++ b/iapyx/src/load/scenario/artificial_users.rs
@@ -104,9 +104,9 @@ impl ArtificialUserLoad {
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("configuration error")]
-    LoadConfigError(#[from] crate::load::config::NodeLoadConfigError),
+    LoadConfig(#[from] crate::load::config::NodeLoadConfigError),
     #[error("configuration error")]
-    ServicingConfigError(#[from] crate::load::config::ServicingStationConfigError),
+    ServicingConfig(#[from] crate::load::config::ServicingStationConfigError),
     #[error("rest error")]
-    RestError(#[from] VitRestError),
+    Rest(#[from] VitRestError),
 }

--- a/iapyx/src/qr/mod.rs
+++ b/iapyx/src/qr/mod.rs
@@ -70,7 +70,7 @@ impl QrReader {
             PinReadMode::Global(ref global) => global,
             _ => panic!("when reading qr from bytes Global pin read mode should be used"),
         };
-        let pin = pin_to_bytes(&pin);
+        let pin = pin_to_bytes(pin);
         let img = image::load_from_memory(&bytes)?;
         let secret = KeyQrCode::decode(img, &pin)?;
         Ok(secret.first().unwrap().clone())

--- a/iapyx/src/stats/block0/wallets.rs
+++ b/iapyx/src/stats/block0/wallets.rs
@@ -36,6 +36,7 @@ pub fn calculate_wallet_distribution<S: Into<String>>(
 
     let mut stats = Stats::new(headers);
 
+    #[allow(clippy::needless_collect)]
     let blacklist: Vec<Address> = genesis
         .blockchain_configuration
         .committees

--- a/iapyx/src/wallet.rs
+++ b/iapyx/src/wallet.rs
@@ -118,6 +118,10 @@ impl Wallet {
         self.inner.set_state(value, counter);
     }
 
+    pub fn spending_counter(&self) -> u32 {
+        self.inner.spending_counter()
+    }
+
     pub fn vote(
         &mut self,
         settings: Settings,

--- a/registration-verify-service/src/job/mod.rs
+++ b/registration-verify-service/src/job/mod.rs
@@ -103,7 +103,7 @@ impl RegistrationVerifyJob {
     ) -> Option<Address> {
         match &request.source {
             Source::PublicKeyBytes(content) => {
-                match chain_crypto::PublicKey::from_binary(&content) {
+                match chain_crypto::PublicKey::from_binary(content) {
                     Ok(public_key) => Some(self.extract_address_from_public_key(
                         public_key,
                         checks,

--- a/vitup/src/interactive/args/show.rs
+++ b/vitup/src/interactive/args/show.rs
@@ -96,15 +96,15 @@ impl VoteTimeStatus {
         let mut dates = vec![
             (
                 "Voting period start",
-                self.calculate_date(&blockchain_configuration, vote_plan.vote_start),
+                self.calculate_date(blockchain_configuration, vote_plan.vote_start),
             ),
             (
                 "Voting period end",
-                self.calculate_date(&blockchain_configuration, vote_plan.vote_end),
+                self.calculate_date(blockchain_configuration, vote_plan.vote_end),
             ),
             (
                 "Tally period end",
-                self.calculate_date(&blockchain_configuration, vote_plan.committee_end),
+                self.calculate_date(blockchain_configuration, vote_plan.committee_end),
             ),
             ("> Current time", Utc::now().naive_utc()),
         ];

--- a/vitup/src/mock/args.rs
+++ b/vitup/src/mock/args.rs
@@ -62,5 +62,5 @@ pub enum Error {
     #[error("context error")]
     Context(#[from] crate::mock::context::Error),
     #[error("join error")]
-    JoinError(#[from] tokio::task::JoinError),
+    Join(#[from] tokio::task::JoinError),
 }

--- a/vitup/src/mock/config.rs
+++ b/vitup/src/mock/config.rs
@@ -20,9 +20,9 @@ pub fn read_config<P: AsRef<Path>>(config: P) -> Result<Configuration, Error> {
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("cannot parse configuration")]
-    CannotParseConfiguration(#[from] serde_json::Error),
+    ParseConfiguration(#[from] serde_json::Error),
     #[error("cannot read configuration: {0:?}")]
-    CannotReadConfiguration(PathBuf),
+    ReadConfiguration(PathBuf),
     #[error("cannot spawn command")]
-    CannotSpawnCommand(#[from] std::io::Error),
+    SpawnCommand(#[from] std::io::Error),
 }

--- a/vitup/src/scenario/controller.rs
+++ b/vitup/src/scenario/controller.rs
@@ -135,7 +135,7 @@ impl VitController {
             pb,
             alias,
             settings.clone(),
-            &block0_file.as_path(),
+            block0_file.as_path(),
             working_directory,
             &version,
         )
@@ -182,8 +182,8 @@ impl VitController {
             alias,
             settings_overriden,
             &node_setting,
-            &block0_file.as_path(),
-            &working_directory.path(),
+            block0_file.as_path(),
+            working_directory.path(),
             params.protocol.clone(),
         )
         .unwrap();

--- a/vitup/src/scenario/vit_station/controller.rs
+++ b/vitup/src/scenario/vit_station/controller.rs
@@ -193,7 +193,7 @@ impl VitStation {
 
         let config_file = dir.join(VIT_CONFIG);
         let db_file = dir.join(STORAGE);
-        dump_settings_to_file(&config_file.to_str().unwrap(), &settings).unwrap();
+        dump_settings_to_file(config_file.to_str().unwrap(), &settings).unwrap();
 
         DbGenerator::new(parameters).build(&db_file, template_generator);
 

--- a/vitup/src/setup/start/quick/builder.rs
+++ b/vitup/src/setup/start/quick/builder.rs
@@ -385,7 +385,7 @@ impl QuickVitBackendSettingsBuilder {
                 .unwrap();
             let png = folder.child(format!("{}_{}.png", alias, pin));
             println!("[{}/{}] Qr dumped to {:?}", idx + 1, total, png.path());
-            wallet.save_qr_code(png.path(), &pin_to_bytes(&pin));
+            wallet.save_qr_code(png.path(), &pin_to_bytes(pin));
 
             let hash = folder.child(format!("{}_{}.txt", alias, pin));
             println!(
@@ -394,7 +394,7 @@ impl QuickVitBackendSettingsBuilder {
                 total,
                 hash.path()
             );
-            wallet.save_qr_code_hash(hash.path(), &pin_to_bytes(&pin))?;
+            wallet.save_qr_code_hash(hash.path(), &pin_to_bytes(pin))?;
         }
 
         if let Some(initials) = &self.parameters.initials {
@@ -504,7 +504,7 @@ impl QuickVitBackendSettingsBuilder {
                 .block0_date,
         );
 
-        let parameters = self.vote_plan_parameters(controller.vote_plans(), &controller.settings());
+        let parameters = self.vote_plan_parameters(controller.vote_plans(), controller.settings());
         Ok((
             vit_controller,
             controller,


### PR DESCRIPTION
Currently --reuse-account-lazy parameter introduced behaviour which force single vote request generator to update wallet from backend before running each vote. This can be problematic when only few addresses are used in load tests. Therefore it will only update before first vote. Then it will still rely on previously implemented autoupdate of  spending counter 