### PR TITLE
Skip qr generation option in generate snapshot

### DIFF
--- a/vitup/src/setup/generate/snapshot.rs
+++ b/vitup/src/setup/generate/snapshot.rs
@@ -86,6 +86,11 @@ impl SnapshotCommandArgs {
                 continue;
             }
 
+            //skip secret key generation
+            if entry.file_name().to_str().unwrap().contains("wallet") {
+                continue;
+            }
+
             std::fs::remove_file(entry.path())?;
         }
 


### PR DESCRIPTION
Small fix for generate snapshot option. Allow to skip qr generation. It is recommended for perf data preparation as we are not using qrs (but secret keys directly)