### PR TITLE
Reviews import

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,10 +159,6 @@ commands:
           command: |
             cargo install --path iapyx --locked
       - run:
-          name: install proxy
-          command: |
-            cargo install --path valgrind --locked
-      - run:
           name: Run tests
           no_output_timeout: 60m
           environment:


### PR DESCRIPTION
In some cases we need to get reviews data to satisfy environment endpoints. However, due to lifecycle of ideascale it is not always possible. Therefore, this simple command will generate review data which: 
- will create 3 reviews per assessor for proposal
- if challenge id = 1 then different tags would be applied from the rest 
- review id should  be unique
- review should correspond to given proposal 

Example of usage:

```
vitup generate data random reviews --proposals proposals.json
```