### PR TITLE
Improve Nix "stuff"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,10 +36,10 @@
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "narHash": "sha256-sDbrmur9Zfp4mPKohCD8IDZfXJ0Tjxpmr2R+kg5PpSY=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "rev": "94aaa8e4720081f9c75497e2735b90f6a819b08e",
         "type": "github"
       },
       "original": {
@@ -53,10 +53,10 @@
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "narHash": "sha256-sDbrmur9Zfp4mPKohCD8IDZfXJ0Tjxpmr2R+kg5PpSY=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "rev": "94aaa8e4720081f9c75497e2735b90f6a819b08e",
         "type": "github"
       },
       "original": {
@@ -69,11 +69,11 @@
     "cabal-34": {
       "flake": false,
       "locked": {
-        "lastModified": 1640353650,
-        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
+        "lastModified": 1622475795,
+        "narHash": "sha256-chwTL304Cav+7p38d9mcb+egABWmxo2Aq+xgVBgEb/U=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
+        "rev": "b086c1995cdd616fc8d91f46a21e905cc50a1049",
         "type": "github"
       },
       "original": {
@@ -86,11 +86,11 @@
     "cabal-34_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1640353650,
-        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
+        "lastModified": 1622475795,
+        "narHash": "sha256-chwTL304Cav+7p38d9mcb+egABWmxo2Aq+xgVBgEb/U=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
+        "rev": "b086c1995cdd616fc8d91f46a21e905cc50a1049",
         "type": "github"
       },
       "original": {
@@ -103,28 +103,11 @@
     "cabal-36": {
       "flake": false,
       "locked": {
-        "lastModified": 1641652457,
-        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
+        "lastModified": 1640163203,
+        "narHash": "sha256-TwDWP2CffT0j40W6zr0J1Qbu+oh3nsF1lUx9446qxZM=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.6",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-36_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641652457,
-        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
+        "rev": "ecf418050c1821f25e2e218f1be94c31e0465df1",
         "type": "github"
       },
       "original": {
@@ -173,7 +156,7 @@
           "voting-tools",
           "nixpkgs"
         ],
-        "utils": "utils_6"
+        "utils": "utils_4"
       },
       "locked": {
         "lastModified": 1635782292,
@@ -254,11 +237,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -274,6 +257,36 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -316,14 +329,55 @@
         "type": "github"
       }
     },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646480205,
+        "narHash": "sha256-kekOlTlu45vuK2L9nq8iVN17V3sB0WWPqTTW3a2SQG0=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "bff2832ec341cf30acb3a4d3e2e7f1f7b590116a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "jormungandr_",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646480205,
+        "narHash": "sha256-kekOlTlu45vuK2L9nq8iVN17V3sB0WWPqTTW3a2SQG0=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "bff2832ec341cf30acb3a4d3e2e7f1f7b590116a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1647306913,
-        "narHash": "sha256-RlnNBE/6wEkfACaAgp6CX8fleDKSYJmBcR5hVeJnA/s=",
+        "lastModified": 1639098768,
+        "narHash": "sha256-DZ4sG8FeDxWvBLixrj0jELXjtebZ0SCCPmQW43HNzIE=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "591cdc67210f9b645face190e5cb689eacef4571",
+        "rev": "c7b123af6b0b9b364cab03363504d42dca16a4b5",
         "type": "github"
       },
       "original": {
@@ -335,11 +389,11 @@
     "hackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1647306913,
-        "narHash": "sha256-RlnNBE/6wEkfACaAgp6CX8fleDKSYJmBcR5hVeJnA/s=",
+        "lastModified": 1643850887,
+        "narHash": "sha256-ETqc0/dNSWmYDmK4iHWZ6WgpIIytww1XPnXIaQEWnqY=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "591cdc67210f9b645face190e5cb689eacef4571",
+        "rev": "111da6040c0d2a183fad3c7b21c10d552be07a66",
         "type": "github"
       },
       "original": {
@@ -353,7 +407,6 @@
         "HTTP": "HTTP",
         "cabal-32": "cabal-32",
         "cabal-34": "cabal-34",
-        "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
         "flake-utils": "flake-utils",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
@@ -372,11 +425,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1647315229,
-        "narHash": "sha256-GRS3fA7jnPY6c+p7xssXthsGG1nG7M+u22DMz9jDZQ4=",
+        "lastModified": 1639098904,
+        "narHash": "sha256-7VrCNEaKGLm4pTOS11dt1dRL2033oqrNCfal0uONsqA=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "eb49a3b7213470e36570f4aa1ed7a64e6d6cf160",
+        "rev": "b18c6ce0867fee77f12ecf41dc6c67f7a59d9826",
         "type": "github"
       },
       "original": {
@@ -390,9 +443,9 @@
         "HTTP": "HTTP_2",
         "cabal-32": "cabal-32_2",
         "cabal-34": "cabal-34_2",
-        "cabal-36": "cabal-36_2",
+        "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell_2",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils_4",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_2",
         "hackage": "hackage_2",
         "hpc-coveralls": "hpc-coveralls_2",
@@ -409,11 +462,11 @@
         "stackage": "stackage_2"
       },
       "locked": {
-        "lastModified": 1647315229,
-        "narHash": "sha256-GRS3fA7jnPY6c+p7xssXthsGG1nG7M+u22DMz9jDZQ4=",
+        "lastModified": 1643851037,
+        "narHash": "sha256-xWZbpGM0euxIWB53gBE3gqU17UY1wFnTWUrKl7FQzUA=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "eb49a3b7213470e36570f4aa1ed7a64e6d6cf160",
+        "rev": "dc4c624fad52d8464c3e849689720f19702a3ef6",
         "type": "github"
       },
       "original": {
@@ -462,11 +515,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1646330344,
-        "narHash": "sha256-EbhMDeneH26wDi+x5kz8nfru/dE9JZ241hJed4a8lz8=",
+        "lastModified": 1633964277,
+        "narHash": "sha256-7G/BK514WiMRr90EswNBthe8SmH9tjPaTBba/RW/VA8=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "0a0126d8fb1bdc61ce1fd2ef61cf396de800fdad",
+        "rev": "1e51437aac8a0e49663cb21e781f34163c81ebfb",
         "type": "github"
       },
       "original": {
@@ -477,11 +530,7 @@
     },
     "iohkNix_2": {
       "inputs": {
-        "nixpkgs": [
-          "voting-tools",
-          "cardano-node",
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1631778944,
@@ -505,11 +554,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1646330344,
-        "narHash": "sha256-EbhMDeneH26wDi+x5kz8nfru/dE9JZ241hJed4a8lz8=",
+        "lastModified": 1643251385,
+        "narHash": "sha256-Czbd69lg0ARSZfC18V6h+gtPMioWDAEVPbiHgL2x9LM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "0a0126d8fb1bdc61ce1fd2ef61cf396de800fdad",
+        "rev": "9d6ee3dcb3482f791e40ed991ad6fc649b343ad4",
         "type": "github"
       },
       "original": {
@@ -518,17 +567,21 @@
         "type": "github"
       }
     },
-    "jormungandr": {
+    "jormungandr_": {
       "inputs": {
+        "flake-utils": "flake-utils_3",
+        "gitignore": "gitignore_2",
+        "naersk": "naersk",
         "nixpkgs": "nixpkgs",
-        "utils": "utils_2"
+        "pre-commit-hooks": "pre-commit-hooks",
+        "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1647328501,
-        "narHash": "sha256-IALYfVVqSHicAhHhSEhyd6D4HtJkBE3MD7x3XgdmHDs=",
+        "lastModified": 1647954688,
+        "narHash": "sha256-FlreaRGpNhKp7q6WLGUYT9YfoteknWgqtMoDb08/VCQ=",
         "owner": "input-output-hk",
         "repo": "jormungandr",
-        "rev": "7979ce37b9cb506b28cf43f654075f2309c1b118",
+        "rev": "baa81f2fc351ac6ce9600726dd2ad90e2673f8d6",
         "type": "github"
       },
       "original": {
@@ -538,14 +591,57 @@
         "type": "github"
       }
     },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "jormungandr_",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1647605581,
+        "narHash": "sha256-56AaI1Zqgxuu+b8o3RbQBP2wtdn3/mQ23eLnkxOtHm8=",
+        "owner": "yusdacra",
+        "repo": "naersk",
+        "rev": "7882e303c4904664194236c921365b4d6b86b9bc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yusdacra",
+        "ref": "feat/cargolock-git-deps",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "naersk_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1647605581,
+        "narHash": "sha256-56AaI1Zqgxuu+b8o3RbQBP2wtdn3/mQ23eLnkxOtHm8=",
+        "owner": "yusdacra",
+        "repo": "naersk",
+        "rev": "7882e303c4904664194236c921365b4d6b86b9bc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yusdacra",
+        "ref": "feat/cargolock-git-deps",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
     "nix-tools": {
       "flake": false,
       "locked": {
-        "lastModified": 1644395812,
-        "narHash": "sha256-BVFk/BEsTLq5MMZvdy3ZYHKfaS3dHrsKh4+tb5t5b58=",
+        "lastModified": 1636018067,
+        "narHash": "sha256-ng306fkuwr6V/malWtt3979iAC4yMVDDH2ViwYB6sQE=",
         "owner": "input-output-hk",
         "repo": "nix-tools",
-        "rev": "d847c63b99bbec78bf83be2a61dc9f09b8a9ccc1",
+        "rev": "ed5bd7215292deba55d6ab7a4e8c21f8b1564dda",
         "type": "github"
       },
       "original": {
@@ -557,11 +653,11 @@
     "nix-tools_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1644395812,
-        "narHash": "sha256-BVFk/BEsTLq5MMZvdy3ZYHKfaS3dHrsKh4+tb5t5b58=",
+        "lastModified": 1636018067,
+        "narHash": "sha256-ng306fkuwr6V/malWtt3979iAC4yMVDDH2ViwYB6sQE=",
         "owner": "input-output-hk",
         "repo": "nix-tools",
-        "rev": "d847c63b99bbec78bf83be2a61dc9f09b8a9ccc1",
+        "rev": "ed5bd7215292deba55d6ab7a4e8c21f8b1564dda",
         "type": "github"
       },
       "original": {
@@ -572,11 +668,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637595801,
-        "narHash": "sha256-LkIMwVFKCuEqidaUdg8uxwpESAXjsPo4oCz3eJ7RaRw=",
+        "lastModified": 1647297614,
+        "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "263ef4cc4146c9fab808085487438c625d4426a9",
+        "rev": "73ad5f9e147c0d2a2061f1d4bd91e05078dc0b58",
         "type": "github"
       },
       "original": {
@@ -620,11 +716,11 @@
     },
     "nixpkgs-2105": {
       "locked": {
-        "lastModified": 1642244250,
-        "narHash": "sha256-vWpUEqQdVP4srj+/YLJRTN9vjpTs4je0cdWKXPbDItc=",
+        "lastModified": 1630481079,
+        "narHash": "sha256-leWXLchbAbqOlLT6tju631G40SzQWPqaAXQG3zH1Imw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0fd9ee1aa36ce865ad273f4f07fdc093adeb5c00",
+        "rev": "110a2c9ebbf5d4a94486854f18a37a938cfacbbb",
         "type": "github"
       },
       "original": {
@@ -636,11 +732,11 @@
     },
     "nixpkgs-2105_2": {
       "locked": {
-        "lastModified": 1642244250,
-        "narHash": "sha256-vWpUEqQdVP4srj+/YLJRTN9vjpTs4je0cdWKXPbDItc=",
+        "lastModified": 1640283157,
+        "narHash": "sha256-6Ddfop+rKE+Gl9Tjp9YIrkfoYPzb8F80ergdjcq3/MY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0fd9ee1aa36ce865ad273f4f07fdc093adeb5c00",
+        "rev": "dde1557825c5644c869c5efc7448dc03722a8f09",
         "type": "github"
       },
       "original": {
@@ -652,11 +748,11 @@
     },
     "nixpkgs-2111": {
       "locked": {
-        "lastModified": 1644510859,
-        "narHash": "sha256-xjpVvL5ecbyi0vxtVl/Fh9bwGlMbw3S06zE5nUzFB8A=",
+        "lastModified": 1638410074,
+        "narHash": "sha256-MQYI4k4XkoTzpeRjq5wl+1NShsl1CKq8MISFuZ81sWs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0d1d5d7e3679fec9d07f2eb804d9f9fdb98378d3",
+        "rev": "5b80f23502f8e902612a8c631dfce383e1c56596",
         "type": "github"
       },
       "original": {
@@ -668,11 +764,11 @@
     },
     "nixpkgs-2111_2": {
       "locked": {
-        "lastModified": 1644510859,
-        "narHash": "sha256-xjpVvL5ecbyi0vxtVl/Fh9bwGlMbw3S06zE5nUzFB8A=",
+        "lastModified": 1640283207,
+        "narHash": "sha256-SCwl7ZnCfMDsuSYvwIroiAlk7n33bW8HFfY8NvKhcPA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0d1d5d7e3679fec9d07f2eb804d9f9fdb98378d3",
+        "rev": "64c7e3388bbd9206e437713351e814366e0c3284",
         "type": "github"
       },
       "original": {
@@ -684,11 +780,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1644486793,
-        "narHash": "sha256-EeijR4guVHgVv+JpOX3cQO+1XdrkJfGmiJ9XVsVU530=",
+        "lastModified": 1635295995,
+        "narHash": "sha256-sGYiXjFlxTTMNb4NSkgvX+knOOTipE6gqwPUQpxNF+c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1882c6b7368fd284ad01b0a5b5601ef136321292",
+        "rev": "22a500a3f87bbce73bd8d777ef920b43a636f018",
         "type": "github"
       },
       "original": {
@@ -700,11 +796,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1644486793,
-        "narHash": "sha256-EeijR4guVHgVv+JpOX3cQO+1XdrkJfGmiJ9XVsVU530=",
+        "lastModified": 1641285291,
+        "narHash": "sha256-KYaOBNGar3XWTxTsYPr9P6u74KAqNq0wobEC236U+0c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1882c6b7368fd284ad01b0a5b5601ef136321292",
+        "rev": "0432195a4b8d68faaa7d3d4b355260a3120aeeae",
         "type": "github"
       },
       "original": {
@@ -716,11 +812,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1647125019,
-        "narHash": "sha256-PXA76/iIqtbrA0ydCyc7Wpdw7TQTnfEowM87YtTXfB4=",
+        "lastModified": 1647800324,
+        "narHash": "sha256-rjwoxrk16zfrcO5Torh6CbAd5GHsHrXw+EwxOvh9AUI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0e141e3fe13ec21f50429773d2e3890e02a80da",
+        "rev": "9bc841fec1c0e8b9772afa29f934d2c7ce57da8e",
         "type": "github"
       },
       "original": {
@@ -762,6 +858,20 @@
         "type": "github"
       }
     },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1643472818,
+        "narHash": "sha256-qzVPxKDUubYIxKRSuDl/JgzXWSmGvUVYny9SxFMfPJM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7f65e4abd5ecaad12d2d26e4380d1a7d8edafea7",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
     "old-ghc-nix": {
       "flake": false,
       "locked": {
@@ -796,13 +906,64 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-utils": [
+          "jormungandr_",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "jormungandr_",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646153636,
+        "narHash": "sha256-AlWHMzK+xJ1mG267FdT8dCq/HvLCA6jwmx2ZUy5O8tY=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "b6bc0b21e1617e2b07d8205e7fae7224036dfa4b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks_2": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646153636,
+        "narHash": "sha256-AlWHMzK+xJ1mG267FdT8dCq/HvLCA6jwmx2ZUy5O8tY=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "b6bc0b21e1617e2b07d8205e7fae7224036dfa4b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "cardano-node": "cardano-node",
-        "jormungandr": "jormungandr",
+        "flake-utils": "flake-utils_2",
+        "gitignore": "gitignore",
+        "jormungandr_": "jormungandr_",
+        "naersk": "naersk_2",
         "nixpkgs": "nixpkgs_2",
-        "rust-nix": "rust-nix",
-        "utils": "utils_3",
+        "pre-commit-hooks": "pre-commit-hooks_2",
+        "rust-overlay": "rust-overlay_2",
         "vit-kedqr": "vit-kedqr",
         "vit-servicing-station": "vit-servicing-station",
         "voting-tools": "voting-tools"
@@ -811,27 +972,7 @@
     "rust-nix": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1617363019,
-        "narHash": "sha256-w9VUHPPndNPGPSumta4cEhhRQBUL1jMxiZmZtwYY8JU=",
-        "owner": "input-output-hk",
-        "repo": "rust.nix",
-        "rev": "2fd5fce3ec67e6915cb79cbf132f023e147b31ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "work",
-        "repo": "rust.nix",
-        "type": "github"
-      }
-    },
-    "rust-nix_2": {
-      "inputs": {
-        "nixpkgs": [
+          "vit-kedqr",
           "nixpkgs"
         ]
       },
@@ -850,14 +991,62 @@
         "type": "github"
       }
     },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "jormungandr_",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "jormungandr_",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1647570584,
+        "narHash": "sha256-wQ/xUt2yU+ncx0JQMMQDcFoWLY2xo0Vo5CxIGuxMdmY=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "00ac40d23ec331be4fd143b8cd3e9142e3bcbe9b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1647916392,
+        "narHash": "sha256-xiZ4Bzj2KLzphnBh6zMBKm/Icc7grN8CcaFepXhx8y4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "a4ba09b440c10a45124aa75667c36549ddadac4d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1647307016,
-        "narHash": "sha256-5aaOk8EYVifi9nSdqR60ZyshgXYCiLrYrKRtPtM5iAQ=",
+        "lastModified": 1639012797,
+        "narHash": "sha256-hiLyBa5XFBvxD+BcYPKyYd/0dNMccxAuywFNqYtIIvs=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "66c6141c830c277ad919fb2a6180ee461ca0238b",
+        "rev": "9ea6ea359da91c75a71e334b25aa7dc5ddc4b2c6",
         "type": "github"
       },
       "original": {
@@ -869,11 +1058,11 @@
     "stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1647307016,
-        "narHash": "sha256-5aaOk8EYVifi9nSdqR60ZyshgXYCiLrYrKRtPtM5iAQ=",
+        "lastModified": 1643764602,
+        "narHash": "sha256-aiwoJ1Ut3kGiDwS+D7ujzd7PLmanS2Kfrr5FJzXh4Kg=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "66c6141c830c277ad919fb2a6180ee461ca0238b",
+        "rev": "ce7bf2a5b014c58f7fdf3220984cf2917c54159b",
         "type": "github"
       },
       "original": {
@@ -884,11 +1073,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1614513358,
-        "narHash": "sha256-LakhOx3S1dRjnh0b5Dg3mbZyH0ToC9I8Y2wKSkBaTzU=",
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5466c5bbece17adaab2d82fae80b46e807611bf3",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
         "type": "github"
       },
       "original": {
@@ -898,36 +1087,6 @@
       }
     },
     "utils_2": {
-      "locked": {
-        "lastModified": 1624650440,
-        "narHash": "sha256-BIwYENLvbSTNYdyeVJihwi7G6bXVGrPNoOgvJ1Z1SlY=",
-        "owner": "kreisys",
-        "repo": "flake-utils",
-        "rev": "026014b92b548ef130a7aebc84a3894f791370fc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kreisys",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "utils_3": {
-      "locked": {
-        "lastModified": 1628100524,
-        "narHash": "sha256-vqI3p9fNj0C4ykTwMjryztszLHq9YU7AUkRJ9BK7rpE=",
-        "owner": "kreisys",
-        "repo": "flake-utils",
-        "rev": "7e5e32b9b20e6091adf27d7cdb1e0a0578b6f4f6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kreisys",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "utils_4": {
       "locked": {
         "lastModified": 1613500319,
         "narHash": "sha256-ybAq6pImFCSnwyhhmnnvV567JM4GuhCEG/PHBkSS86U=",
@@ -942,7 +1101,7 @@
         "type": "github"
       }
     },
-    "utils_5": {
+    "utils_3": {
       "locked": {
         "lastModified": 1633020561,
         "narHash": "sha256-4uAiRqL9nP3d/NQ8VBqjQ5iZypHaM+X/FyWpXVXkwTA=",
@@ -957,7 +1116,7 @@
         "type": "github"
       }
     },
-    "utils_6": {
+    "utils_4": {
       "locked": {
         "lastModified": 1623875721,
         "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
@@ -972,7 +1131,7 @@
         "type": "github"
       }
     },
-    "utils_7": {
+    "utils_5": {
       "locked": {
         "lastModified": 1610051610,
         "narHash": "sha256-U9rPz/usA1/Aohhk7Cmc2gBrEEKRzcW4nwPWMPwja4Y=",
@@ -990,8 +1149,8 @@
     "vit-kedqr": {
       "inputs": {
         "nixpkgs": "nixpkgs_3",
-        "rust-nix": "rust-nix_2",
-        "utils": "utils_4"
+        "rust-nix": "rust-nix",
+        "utils": "utils_2"
       },
       "locked": {
         "lastModified": 1618475598,
@@ -1010,14 +1169,14 @@
     "vit-servicing-station": {
       "inputs": {
         "nixpkgs": "nixpkgs_4",
-        "utils": "utils_5"
+        "utils": "utils_3"
       },
       "locked": {
-        "lastModified": 1647343434,
-        "narHash": "sha256-qY7DG82UdBzVUtoQo7vU8Cx2TD/F3FGyz/x92zXdPCM=",
+        "lastModified": 1647612501,
+        "narHash": "sha256-+bbk1bnj/9gVP4QFeDAq6tFhz/5jrkDCJkWtXIBVuHQ=",
         "owner": "input-output-hk",
         "repo": "vit-servicing-station",
-        "rev": "87f7918325896d01433cfd75f958517c71a955b0",
+        "rev": "23b4d06ff40cb35598d7009147201a0389eca2c5",
         "type": "github"
       },
       "original": {
@@ -1037,7 +1196,7 @@
           "haskellNix",
           "nixpkgs-2105"
         ],
-        "utils": "utils_7"
+        "utils": "utils_5"
       },
       "locked": {
         "lastModified": 1643912915,

--- a/flake.nix
+++ b/flake.nix
@@ -1,111 +1,204 @@
 {
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    utils.url = "github:kreisys/flake-utils";
-    rust-nix.url = "github:input-output-hk/rust.nix/work";
-    rust-nix.inputs.nixpkgs.follows = "nixpkgs";
-    voting-tools.url =
-      "github:input-output-hk/voting-tools?rev=6da7c45cbd1c756285ca2a1db99f82dd1a8cc16b";
-    vit-kedqr.url = "github:input-output-hk/vit-kedqr";
-    vit-servicing-station.url = "github:input-output-hk/vit-servicing-station/master";
-    jormungandr.url = "github:input-output-hk/jormungandr/master";
-    cardano-node.url = "github:input-output-hk/cardano-node/1.33.0";
-  };
-  outputs = { self
-            , nixpkgs
-            , utils
-            , rust-nix
-            , voting-tools
-            , vit-kedqr
-            , vit-servicing-station
-            , jormungandr
-            , cardano-node
-            }:
-    let
-      workspaceCargo = builtins.fromTOML (builtins.readFile ./Cargo.toml);
-      inherit (workspaceCargo.workspace) members;
-    in utils.lib.simpleFlake {
-      inherit nixpkgs;
+  description = "Incubator for catalyst related testing projects";
 
-      systems = [ "x86_64-linux" ];
+  nixConfig.extra-substituters = [
+    "https://hydra.iohk.io"
+    "https://vit-ops.cachix.org"
+  ];
+  nixConfig.extra-trusted-public-keys = [
+    "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+    "vit-ops.cachix.org-1:LY84nIKdW7g1cvhJ6LsupHmGtGcKAlUXo+l1KByoDho="
+  ];
 
-      preOverlays = let
-        cargo-packages = final: prev:
-          let lib = prev.lib;
-          in lib.listToAttrs (lib.forEach members (member:
-            lib.nameValuePair member (final.rust-nix.buildPackage {
-              inherit ((builtins.fromTOML
-                (builtins.readFile (./. + "/${member}/Cargo.toml"))).package)
-                name version;
-              root = ./.;
-              nativeBuildInputs = with final; [ pkg-config protobuf rustfmt ];
-              buildInputs = with final; [ openssl ];
-              PROTOC = "${final.protobuf}/bin/protoc";
-              PROTOC_INCLUDE = "${final.protobuf}/include";
-            })));
-      in [ rust-nix cargo-packages ];
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.gitignore.url = "github:hercules-ci/gitignore.nix";
+  inputs.gitignore.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
+  inputs.pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.pre-commit-hooks.inputs.flake-utils.follows = "flake-utils";
+  inputs.rust-overlay.url = "github:oxalica/rust-overlay";
+  inputs.rust-overlay.inputs.flake-utils.follows = "flake-utils";
+  inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+  # XXX: https://github.com/nix-community/naersk/pull/167
+  #inputs.naersk.url = "github:nix-community/naersk";
+  inputs.naersk.url = "github:yusdacra/naersk/feat/cargolock-git-deps";
+  inputs.naersk.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.voting-tools.url = "github:input-output-hk/voting-tools?rev=6da7c45cbd1c756285ca2a1db99f82dd1a8cc16b";
+  inputs.vit-kedqr.url = "github:input-output-hk/vit-kedqr";
+  inputs.vit-servicing-station.url = "github:input-output-hk/vit-servicing-station/master";
+  inputs.jormungandr_.url = "github:input-output-hk/jormungandr/master";
+  inputs.cardano-node.url = "github:input-output-hk/cardano-node/1.33.0";
 
-      overlay = final: prev: {
-        inherit (voting-tools.packages.${final.system}) voting-tools;
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    gitignore,
+    pre-commit-hooks,
+    rust-overlay,
+    naersk,
+    voting-tools,
+    vit-kedqr,
+    vit-servicing-station,
+    jormungandr_,
+    cardano-node,
+  }:
+    flake-utils.lib.eachSystem
+    [
+      flake-utils.lib.system.x86_64-linux
+      flake-utils.lib.system.aarch64-linux
+    ]
+    (
+      system: let
+        readTOML = file: builtins.fromTOML (builtins.readFile file);
+        workspaceCargo = readTOML ./Cargo.toml;
 
-        snapshot-trigger-service = prev.snapshot-trigger-service.overrideAttrs
-          (oldAttrs: {
-            nativeBuildInputs = oldAttrs.nativeBuildInputs
-              ++ [ final.makeWrapper ];
-            postInstall = ''
-              wrapProgram $out/bin/snapshot-trigger-service --prefix PATH : ${
-                final.lib.makeBinPath [ final.voting-tools ]
-              }
-            '';
-          });
-
-        registration-service = prev.registration-service.overrideAttrs
-          (oldAttrs: {
-            nativeBuildInputs = oldAttrs.nativeBuildInputs
-              ++ [ final.makeWrapper ];
-            postInstall = ''
-              wrapProgram $out/bin/registration-service --prefix PATH : ${
-                final.lib.makeBinPath [
-                  voting-tools.packages.${final.system}.voter-registration
-                  vit-kedqr.packages.${final.system}.vit-kedqr
-                  jormungandr.packages.${final.system}.jcli
-                  cardano-node.packages.${final.system}.cardano-cli
-                ]
-              }
-            '';
-          });
-
-        registration-verify-service = prev.registration-verify-service.overrideAttrs
-          (oldAttrs: {
-            nativeBuildInputs = oldAttrs.nativeBuildInputs
-              ++ [ final.makeWrapper ];
-            postInstall = ''
-              wrapProgram $out/bin/registration-verify-service --prefix PATH : ${
-                final.lib.makeBinPath [
-                  jormungandr.packages.${final.system}.jcli
-                ]
-              }
-            '';
-          });
-      };
-
-      packages = { iapyx, vitup, integration-tests, snapshot-trigger-service
-        , registration-service, registration-verify-service }@pkgs:
-        pkgs;
-
-      devShell = { system, mkShell, rustc, cargo, pkg-config, openssl, protobuf, rustfmt }:
-        mkShell {
-          PROTOC = "${protobuf}/bin/protoc";
-          PROTOC_INCLUDE = "${protobuf}/include";
-          buildInputs = [ rustc cargo pkg-config openssl protobuf rustfmt ];
-          shellHook = ''
-            export PATH="${jormungandr.packages.${system}.jormungandr}/bin:$PATH"
-            export PATH="${vit-servicing-station.legacyPackages.${system}.vit-servicing-station-server}/bin:$PATH"
-          '';
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [(import rust-overlay)];
         };
 
-      hydraJobs = { iapyx, vitup, integration-tests, snapshot-trigger-service
-        , registration-service, registration-verify-service }@pkgs:
-        pkgs;
-    };
+        inherit (voting-tools.packages.${system}) voting-tools voter-registration;
+        inherit (jormungandr_.packages.${system}) jormungandr jcli;
+        inherit (vit-servicing-station.legacyPackages.${system}) vit-servicing-station-server;
+        inherit (cardano-node.packages.${system}) cardano-cli;
+
+        rust = let
+          _rust = pkgs.rust-bin.stable.latest.default.override {
+            extensions = [
+              "rust-src"
+              "rust-analysis"
+              "rls-preview"
+              "rustfmt-preview"
+              "clippy-preview"
+            ];
+          };
+        in
+          pkgs.buildEnv {
+            name = _rust.name;
+            inherit (_rust) meta;
+            buildInputs = [pkgs.makeWrapper];
+            paths = [_rust];
+            pathsToLink = ["/" "/bin"];
+            # XXX: This is needed because cargo and clippy commands need to
+            # also be aware of other binaries in order to work properly.
+            # https://github.com/cachix/pre-commit-hooks.nix/issues/126
+            postBuild = ''
+              for i in $out/bin/*; do
+                wrapProgram "$i" --prefix PATH : "$out/bin"
+              done
+            '';
+          };
+
+        naersk-lib = naersk.lib."${system}".override {
+          cargo = rust;
+          rustc = rust;
+        };
+
+        mkPackage = name: let
+          pkgCargo = readTOML ./${name}/Cargo.toml;
+          cargoOptions = [ "--package" name ];
+        in
+          naersk-lib.buildPackage {
+            root = gitignore.lib.gitignoreSource self;
+
+            cargoBuildOptions = x: x ++ cargoOptions;
+            cargoTestOptions = x: x ++ cargoOptions;
+
+            PROTOC = "${pkgs.protobuf}/bin/protoc";
+            PROTOC_INCLUDE = "${pkgs.protobuf}/include";
+
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+              protobuf
+              rustfmt
+            ] ++ (pkgs.lib.optional
+              (builtins.elem name [ "snapshot-trigger-service"
+                                    "registration-service"
+                                    "registration-verify-service"
+                                  ])
+              pkgs.makeWrapper);
+
+            buildInputs = with pkgs; [
+              openssl
+            ];
+
+            postInstall =
+              if name == "snapshot-trigger-service" then
+                "wrapProgram $out/bin/${name} --prefix PATH : ${pkgs.lib.makeBinPath [ voting-tools ]}"
+              else if name == "registration-service" then
+                "wrapProgram $out/bin/${name} --prefix PATH : ${pkgs.lib.makeBinPath [ vit-kedqr jcli cardano-cli ]}"
+              else if name == "registration-verify-service" then
+                "wrapProgram $out/bin/${name} --prefix PATH : ${pkgs.lib.makeBinPath [ jcli ]}"
+              else
+                "";
+          };
+
+        workspace =
+          builtins.listToAttrs
+          (
+            builtins.map
+            (name: {
+              inherit name;
+              value = mkPackage name;
+            })
+            workspaceCargo.workspace.members
+          );
+
+        pre-commit = pre-commit-hooks.lib.${system}.run {
+          src = self;
+          hooks = {
+            alejandra = {
+              enable = true;
+            };
+            rustfmt = {
+              enable = true;
+              entry = pkgs.lib.mkForce "${rust}/bin/cargo-fmt fmt -- --check --color always";
+            };
+          };
+        };
+
+        warnToUpdateNix = pkgs.lib.warn "Consider updating to Nix > 2.7 to remove this warning!";
+      in rec {
+        packages = {
+          inherit (workspace)
+              iapyx
+              vitup
+              integration-tests
+              snapshot-trigger-service
+              registration-service
+              registration-verify-service;
+          inherit voting-tools;
+          default = workspace.vitup;
+        };
+
+        devShells.default = pkgs.mkShell {
+          PROTOC = "${pkgs.protobuf}/bin/protoc";
+          PROTOC_INCLUDE = "${pkgs.protobuf}/include";
+          buildInputs =
+            [rust]
+            ++ (with pkgs; [
+              pkg-config
+              openssl
+              protobuf
+            ]);
+          shellHook =
+            pre-commit.shellHook
+            + ''
+              export PATH="${jormungandr}/bin:$PATH"
+              export PATH="${vit-servicing-station-server}/bin:$PATH"
+              echo "=== Development shell ==="
+              echo "Info: Git hooks can be installed using \`pre-commit install\`"
+            '';
+        };
+
+        checks.pre-commit = pre-commit;
+
+        hydraJobs = packages;
+
+        defaultPackage = warnToUpdateNix packages.default;
+        devShell = warnToUpdateNix devShells.default;
+      }
+    );
 }


### PR DESCRIPTION
* Update github actions on a daily basis.
* New github workflow that updates flake inputs weekly.
* Use upstream [flake-utils](https://github.com/numtide/flake-utils) (no need to use the fork)
* Use [gitignore.nix](https://github.com/hercules-ci/gitignore.nix) to filter out not needed source files. That
* Use [direnv](https://direnv.net/) to automatically enter the nix development environment.
* Use [pre-commit.nix](https://github.com/cachix/pre-commit-hooks.nix/) to force rust and nix formatter.
* Use [rust-overlay](https://github.com/oxalica/rust-overlay) to follow latest stable rust compiler.
* Use [naersk](https://github.com/nix-community/naersk) to load cargo dependencies from Cargo.lock file.

This is a similar change that was done in jormugandr, https://github.com/input-output-hk/jormungandr/pull/3894