### PR TITLE
Added tag field to request for snapshot trigger service

### DIFF
--- a/integration-tests/src/e2e/testnet.rs
+++ b/integration-tests/src/e2e/testnet.rs
@@ -30,6 +30,7 @@ pub fn e2e_flow_using_voter_registration_local_vitup_and_iapyx() {
 
     let job_param = JobParameters {
         slot_no: Some(result.slot_no().unwrap() + GRACE_PERIOD_FOR_SNAPSHOT),
+        tag: None,
     };
 
     wait_for_db_sync();

--- a/integration-tests/src/snapshot/testnet.rs
+++ b/integration-tests/src/snapshot/testnet.rs
@@ -29,6 +29,7 @@ pub fn multiple_registration() {
 
     let job_param = JobParameters {
         slot_no: Some(second_registartion.slot_no().unwrap() + GRACE_PERIOD_FOR_SNAPSHOT),
+        tag: None,
     };
 
     wait_for_db_sync();
@@ -52,6 +53,7 @@ pub fn wallet_has_less_than_threshold() {
 
     let job_param = JobParameters {
         slot_no: Some(registartion.slot_no().unwrap() + GRACE_PERIOD_FOR_SNAPSHOT),
+        tag: None,
     };
 
     wait_for_db_sync();
@@ -75,6 +77,7 @@ pub fn wallet_with_funds_equals_to_threshold_should_be_elligible_to_vote() {
 
     let job_param = JobParameters {
         slot_no: Some(registartion.slot_no().unwrap() + GRACE_PERIOD_FOR_SNAPSHOT),
+        tag: None,
     };
 
     wait_for_db_sync();
@@ -95,6 +98,7 @@ pub fn registration_after_snapshot_is_not_taken_into_account() {
 
     let job_param = JobParameters {
         slot_no: Some(registartion.slot_no().unwrap() - 1),
+        tag: None,
     };
 
     wait_for_db_sync();

--- a/registration-verify-service/src/job/mod.rs
+++ b/registration-verify-service/src/job/mod.rs
@@ -151,6 +151,7 @@ impl RegistrationVerifyJob {
     pub fn start(&self, request: Request, context: ContextLock) -> Result<JobOutputInfo, Error> {
         let jobs_params = JobParameters {
             slot_no: request.slot_no,
+            tag: request.tag.clone(),
         };
 
         let registration = RegistrationInfo {

--- a/registration-verify-service/src/multipart.rs
+++ b/registration-verify-service/src/multipart.rs
@@ -94,6 +94,7 @@ pub async fn parse_multipart(form: warp::multipart::FormData) -> Result<Request,
         expected_funds,
         threshold,
         slot_no,
+        tag: None,
     })
 }
 

--- a/registration-verify-service/src/request.rs
+++ b/registration-verify-service/src/request.rs
@@ -7,6 +7,7 @@ pub struct Request {
     pub expected_funds: u64,
     pub threshold: u64,
     pub slot_no: Option<u64>,
+    pub tag: Option<String>,
 }
 
 impl fmt::Debug for Request {

--- a/snapshot-trigger-service/src/args/mod.rs
+++ b/snapshot-trigger-service/src/args/mod.rs
@@ -50,12 +50,13 @@ impl TriggerServiceCommand {
                     control_context.lock().unwrap().run_started().unwrap();
 
                     child.wait().unwrap();
-                    control_context.lock().unwrap().run_finished().unwrap();
 
                     let status = control_context.lock().unwrap().status_by_id(job_id)?;
                     job_result_dir.push("status.yaml");
                     persist_status(&job_result_dir, status)
                         .map_err(|_| Error::CannotPersistJobState)?;
+
+                    control_context.lock().unwrap().run_finished().unwrap();
                 }
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
             }

--- a/snapshot-trigger-service/src/client/args.rs
+++ b/snapshot-trigger-service/src/client/args.rs
@@ -99,12 +99,16 @@ pub struct NewJobCommand {
     /// slot no
     #[structopt(short, long)]
     slot_no: Option<u64>,
+    /// tag
+    #[structopt(short, long)]
+    tag: Option<String>,
 }
 
 impl NewJobCommand {
     pub fn exec(self, rest: SnapshotRestClient) -> Result<String, Error> {
         let params = JobParameters {
             slot_no: self.slot_no,
+            tag: self.tag,
         };
         rest.job_new(params).map_err(Into::into)
     }

--- a/snapshot-trigger-service/src/client/mod.rs
+++ b/snapshot-trigger-service/src/client/mod.rs
@@ -92,7 +92,7 @@ impl SnapshotResult {
     }
 
     pub fn status(&self) -> State {
-        self.status
+        self.status.clone()
     }
 
     pub fn initials(&self) -> &Vec<Initial> {

--- a/snapshot-trigger-service/src/config/job.rs
+++ b/snapshot-trigger-service/src/config/job.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 pub struct JobParameters {
     #[serde(rename = "slot-no")]
     pub slot_no: Option<u64>,
+    pub tag: Option<String>,
 }

--- a/snapshot-trigger-service/src/config/mod.rs
+++ b/snapshot-trigger-service/src/config/mod.rs
@@ -32,6 +32,8 @@ impl Configuration {
             NetworkType::Testnet(magic) => command.arg("--testnet-magic").arg(magic.to_string()),
         };
 
+        let output_filename = self.crate_snapshot_output_file_name(&params.tag);
+
         command
             .arg("--db")
             .arg(&self.voting_tools.db)
@@ -40,7 +42,7 @@ impl Configuration {
             .arg("--db-host")
             .arg(&self.voting_tools.db_host)
             .arg("--out-file")
-            .arg(output_folder.join("snapshot.json"))
+            .arg(output_folder.join(output_filename))
             .arg("--scale")
             .arg(self.voting_tools.scale.to_string());
 
@@ -50,6 +52,16 @@ impl Configuration {
 
         println!("Running command: {:?} ", command);
         command.spawn().map_err(Into::into)
+    }
+
+    pub fn crate_snapshot_output_file_name(&self, tag: &Option<String>) -> String {
+        const SNAPSHOT_FILE: &str = "snapshot.json";
+
+        if let Some(tag) = tag {
+            format!("{}_{}", tag, SNAPSHOT_FILE)
+        } else {
+            SNAPSHOT_FILE.to_string()
+        }
     }
 }
 

--- a/snapshot-trigger-service/src/context.rs
+++ b/snapshot-trigger-service/src/context.rs
@@ -54,7 +54,7 @@ impl Context {
     }
 
     pub fn run_started(&mut self) -> Result<(), Error> {
-        match self.state {
+        match self.state.clone() {
             State::RequestToStart { job_id, parameters } => {
                 self.state = State::Running {
                     job_id,
@@ -68,7 +68,7 @@ impl Context {
     }
 
     pub fn run_finished(&mut self) -> Result<(), Error> {
-        match self.state {
+        match self.state.clone() {
             State::Running {
                 job_id,
                 start,
@@ -89,17 +89,17 @@ impl Context {
     pub fn status_by_id(&self, id: Uuid) -> Result<State, Error> {
         match self.state {
             State::Idle => Err(Error::NoJobRun),
-            State::RequestToStart { .. } => Ok(self.state),
+            State::RequestToStart { .. } => Ok(self.state.clone()),
             State::Running { job_id, .. } => {
                 if job_id == id {
-                    Ok(self.state)
+                    Ok(self.state.clone())
                 } else {
                     Err(Error::JobNotFound)
                 }
             }
             State::Finished { job_id, .. } => {
                 if job_id == id {
-                    Ok(self.state)
+                    Ok(self.state.clone())
                 } else {
                     Err(Error::JobNotFound)
                 }
@@ -132,7 +132,7 @@ impl Context {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Copy, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
 pub enum State {
     Idle,
     RequestToStart {

--- a/snapshot-trigger-service/src/rest.rs
+++ b/snapshot-trigger-service/src/rest.rs
@@ -131,7 +131,6 @@ pub async fn health_handler() -> Result<impl Reply, Rejection> {
 
 pub async fn files_handler(context: ContextLock) -> Result<impl Reply, Rejection> {
     let context_lock = context.lock().unwrap();
-    println!("Reading files from: {:?}", context_lock.working_directory());
     Ok(file_lister::dump_json(context_lock.working_directory())?).map(|r| warp::reply::json(&r))
 }
 

--- a/snapshot-trigger-service/src/service.rs
+++ b/snapshot-trigger-service/src/service.rs
@@ -39,7 +39,7 @@ impl ManagerService {
 
     pub fn request_to_start(&self) -> Option<(Uuid, JobParameters)> {
         match self.context.lock().unwrap().state() {
-            State::RequestToStart { job_id, parameters } => Some((*job_id, *parameters)),
+            State::RequestToStart { job_id, parameters } => Some((*job_id, (*parameters).clone())),
             _ => None,
         }
     }


### PR DESCRIPTION
This will result in different snapshot output prefix. Currently its `{tag}_snapshot.json`, while by default if tag is not provided output file will be named like before `snapshot.json`