### PR TITLE
add snapshot mock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,12 +286,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
 
 [[package]]
-name = "beef"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bed554bd50246729a1ec158d08aa3235d1b69d94ad120ebe187e28894787e736"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,10 +488,9 @@ dependencies = [
 [[package]]
 name = "cardano-legacy-address"
 version = "0.1.1"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#41325015888e0a62a3e3b1718c278d4bec9d71f8"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
 dependencies = [
  "cbor_event",
- "chain-ser",
  "cryptoxide 0.4.2",
  "ed25519-bip32 0.4.1",
 ]
@@ -618,7 +611,7 @@ dependencies = [
 [[package]]
 name = "chain-addr"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#41325015888e0a62a3e3b1718c278d4bec9d71f8"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
 dependencies = [
  "bech32 0.8.1",
  "chain-core",
@@ -632,7 +625,7 @@ dependencies = [
 [[package]]
 name = "chain-core"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#41325015888e0a62a3e3b1718c278d4bec9d71f8"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
 dependencies = [
  "chain-ser",
 ]
@@ -640,7 +633,7 @@ dependencies = [
 [[package]]
 name = "chain-crypto"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#41325015888e0a62a3e3b1718c278d4bec9d71f8"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
 dependencies = [
  "bech32 0.8.1",
  "cryptoxide 0.4.2",
@@ -662,10 +655,9 @@ dependencies = [
 [[package]]
 name = "chain-evm"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#41325015888e0a62a3e3b1718c278d4bec9d71f8"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
 dependencies = [
  "aurora-bn",
- "base64 0.13.0",
  "blake2",
  "byte-slice-cast",
  "chain-ser",
@@ -675,7 +667,6 @@ dependencies = [
  "hex",
  "imhamt",
  "libsecp256k1",
- "logos",
  "num",
  "quickcheck",
  "ripemd",
@@ -683,13 +674,12 @@ dependencies = [
  "sha2 0.10.2",
  "sha3 0.10.1",
  "thiserror",
- "wee_alloc",
 ]
 
 [[package]]
 name = "chain-impl-mockchain"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#41325015888e0a62a3e3b1718c278d4bec9d71f8"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
 dependencies = [
  "cardano-legacy-address",
  "chain-addr",
@@ -729,7 +719,7 @@ dependencies = [
 [[package]]
 name = "chain-ser"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#41325015888e0a62a3e3b1718c278d4bec9d71f8"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
 dependencies = [
  "thiserror",
 ]
@@ -737,7 +727,7 @@ dependencies = [
 [[package]]
 name = "chain-storage"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#41325015888e0a62a3e3b1718c278d4bec9d71f8"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
 dependencies = [
  "criterion",
  "data-pile",
@@ -750,7 +740,7 @@ dependencies = [
 [[package]]
 name = "chain-time"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#41325015888e0a62a3e3b1718c278d4bec9d71f8"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
 dependencies = [
  "chain-core",
  "chain-ser",
@@ -762,7 +752,7 @@ dependencies = [
 [[package]]
 name = "chain-vote"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#41325015888e0a62a3e3b1718c278d4bec9d71f8"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
 dependencies = [
  "cfg-if 1.0.0",
  "chain-core",
@@ -825,10 +815,34 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "term_size",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "535434c063ced786eb04aaf529308092c5ab60889e8fe24275d15de07b01fa97"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_lex",
+ "indexmap",
+ "strsim 0.10.0",
+ "termcolor",
+ "terminal_size",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -947,7 +961,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools 0.10.3",
@@ -2191,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "hersir"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#a5ce1309f5465706a9d1ec3c87e5951ad1844c31"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#fe45259f818ade0c74f4e273573e001d633e98e5"
 dependencies = [
  "assert_fs",
  "chain-addr",
@@ -2536,7 +2550,7 @@ dependencies = [
 [[package]]
 name = "imhamt"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#41325015888e0a62a3e3b1718c278d4bec9d71f8"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
 dependencies = [
  "proptest",
  "rustc_version",
@@ -2707,7 +2721,7 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 [[package]]
 name = "jcli"
 version = "0.13.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#a5ce1309f5465706a9d1ec3c87e5951ad1844c31"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#fe45259f818ade0c74f4e273573e001d633e98e5"
 dependencies = [
  "base64 0.13.0",
  "bech32 0.8.1",
@@ -2719,7 +2733,7 @@ dependencies = [
  "chain-impl-mockchain",
  "chain-time",
  "chain-vote",
- "clap",
+ "clap 3.1.14",
  "ed25519-bip32 0.4.1",
  "gtmpl",
  "hex",
@@ -2750,7 +2764,7 @@ dependencies = [
 [[package]]
 name = "jormungandr-automation"
 version = "0.13.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#a5ce1309f5465706a9d1ec3c87e5951ad1844c31"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#fe45259f818ade0c74f4e273573e001d633e98e5"
 dependencies = [
  "assert_cmd 2.0.4",
  "assert_fs",
@@ -2814,7 +2828,7 @@ dependencies = [
 [[package]]
 name = "jormungandr-integration-tests"
 version = "0.13.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#a5ce1309f5465706a9d1ec3c87e5951ad1844c31"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#fe45259f818ade0c74f4e273573e001d633e98e5"
 dependencies = [
  "assert_cmd 2.0.4",
  "assert_fs",
@@ -2866,7 +2880,7 @@ dependencies = [
 [[package]]
 name = "jormungandr-lib"
 version = "0.13.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#a5ce1309f5465706a9d1ec3c87e5951ad1844c31"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#fe45259f818ade0c74f4e273573e001d633e98e5"
 dependencies = [
  "base64 0.13.0",
  "bech32 0.8.1",
@@ -3095,33 +3109,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "logos"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427e2abca5be13136da9afdbf874e6b34ad9001dd70f2b103b083a85daa7b345"
-dependencies = [
- "logos-derive",
-]
-
-[[package]]
-name = "logos-derive"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56a7d287fd2ac3f75b11f19a1c8a874a7d55744bd91f7a1b3e7cf87d4343c36d"
-dependencies = [
- "beef",
- "fnv",
- "proc-macro2 1.0.36",
- "quote 1.0.16",
- "regex-syntax",
- "syn 1.0.89",
- "utf8-ranges",
-]
-
-[[package]]
 name = "loki"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#a5ce1309f5465706a9d1ec3c87e5951ad1844c31"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#fe45259f818ade0c74f4e273573e001d633e98e5"
 dependencies = [
  "chain-addr",
  "chain-core",
@@ -3199,12 +3189,6 @@ checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "memory_units"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "migrations_internals"
@@ -3319,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "mjolnir"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#a5ce1309f5465706a9d1ec3c87e5951ad1844c31"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#fe45259f818ade0c74f4e273573e001d633e98e5"
 dependencies = [
  "assert_fs",
  "chain-addr",
@@ -3670,6 +3654,12 @@ dependencies = [
  "log",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
 name = "output_vt100"
@@ -5196,7 +5186,7 @@ dependencies = [
 [[package]]
 name = "sparse-array"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#41325015888e0a62a3e3b1718c278d4bec9d71f8"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
 
 [[package]]
 name = "spin"
@@ -5288,7 +5278,7 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -5475,16 +5465,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term_size"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5527,8 +5507,16 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "term_size",
  "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+dependencies = [
+ "terminal_size",
 ]
 
 [[package]]
@@ -5554,7 +5542,7 @@ dependencies = [
 [[package]]
 name = "thor"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#a5ce1309f5465706a9d1ec3c87e5951ad1844c31"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#fe45259f818ade0c74f4e273573e001d633e98e5"
 dependencies = [
  "assert_fs",
  "bech32 0.8.1",
@@ -6090,7 +6078,7 @@ dependencies = [
 [[package]]
 name = "typed-bytes"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#41325015888e0a62a3e3b1718c278d4bec9d71f8"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
 
 [[package]]
 name = "typenum"
@@ -6212,12 +6200,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf8-ranges"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 
 [[package]]
 name = "uuid"
@@ -6377,6 +6359,7 @@ dependencies = [
  "chain-time",
  "chain-vote",
  "console",
+ "csv",
  "ctrlc",
  "custom_debug",
  "dialoguer 0.10.0",
@@ -6397,6 +6380,7 @@ dependencies = [
  "json",
  "lazy_static",
  "poldercast 0.14.0-dev",
+ "proptest",
  "quickcheck",
  "quickcheck_macros",
  "rand 0.8.5",
@@ -6426,6 +6410,7 @@ dependencies = [
  "valgrind",
  "vit-servicing-station-lib",
  "vit-servicing-station-tests",
+ "voting-hir",
  "walkdir",
  "warp",
  "warp-reverse-proxy",
@@ -6437,6 +6422,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "voting-hir"
+version = "0.1.0"
+source = "git+https://github.com/input-output-hk/catalyst-toolbox.git?branch=main#9d638274cd36cae2567089603b4d3843c7bea0e4"
+dependencies = [
+ "jormungandr-lib",
+ "serde",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -6691,18 +6685,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
 dependencies = [
  "webpki 0.22.0",
-]
-
-[[package]]
-name = "wee_alloc"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "memory_units",
- "winapi 0.3.9",
 ]
 
 [[package]]

--- a/doc/vitup/mock.md
+++ b/doc/vitup/mock.md
@@ -188,3 +188,15 @@ example:
 ```
 vitup-cli --endpoint {mock} disruption control health
 ```
+
+
+##### Add new voters snapshot for specific tag
+
+Add (or overwrite) voters snapshot for this particular tag
+
+```
+curl --location --request POST 'http://{mock_address}/api/control/command/add-snapshot/{tag}' \
+--header 'Content-Type: application/json' \
+--data-raw '
+  [{"voting_group":"direct","voting_key":"241799302733178aca5c0beaa7a43d054cafa36ca5f929edd46313d49e6a0fd5","voting_power":10131166116863755484},{"voting_group":"dreps","voting_key":"0e3fe9b3e4098759df6f7b44bd9b962a53e4b7b821d50bb72cbcdf1ff7f669f8","voting_power":9327154517439309883}]'
+```

--- a/vitup/Cargo.toml
+++ b/vitup/Cargo.toml
@@ -21,6 +21,7 @@ chain-addr           = { git = "https://github.com/input-output-hk/chain-libs.gi
 chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master", features = [ "property-test-api" ] }
 chain-time           = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 chain-vote           = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+proptest = { git = "https://github.com/input-output-hk/proptest.git" }
 jormungandr-lib = { git = "https://github.com/input-output-hk/jormungandr.git", branch = "master" }
 jormungandr-automation = { git = "https://github.com/input-output-hk/jormungandr.git", branch = "master" }
 thor = { git = "https://github.com/input-output-hk/jormungandr.git", branch = "master" }
@@ -29,6 +30,7 @@ jortestkit = { git = "https://github.com/input-output-hk/jortestkit.git", branch
 vit-servicing-station-tests = { git = "https://github.com/input-output-hk/vit-servicing-station.git", branch = "master" }
 vit-servicing-station-lib = { git = "https://github.com/input-output-hk/vit-servicing-station.git", branch = "master" }
 catalyst-toolbox = { git = "https://github.com/input-output-hk/catalyst-toolbox.git", branch = "main"}
+voting-hir = { git = "https://github.com/input-output-hk/catalyst-toolbox.git", branch = "main", features = ["serde"] }
 valgrind = { path = "../valgrind" }
 poldercast = { git = "https://github.com/primetype/poldercast.git", rev = "8305f1560392a9d26673ca996e7646c8834533ef" }
 rand = "0.8"

--- a/vitup/src/mode/mock/mock_state.rs
+++ b/vitup/src/mode/mock/mock_state.rs
@@ -1,4 +1,4 @@
-use super::{Configuration as MockConfig, LedgerState};
+use super::{snapshot::VoterSnapshot, Configuration as MockConfig, LedgerState};
 use crate::builders::utils::SessionSettingsExtension;
 use crate::builders::VitBackendSettingsBuilder;
 use crate::config::Config;
@@ -19,6 +19,8 @@ pub struct MockState {
     version: VitVersion,
     ledger_state: LedgerState,
     vit_state: Snapshot,
+    // ATTENTION: this is not in sync with the ledger
+    voters: VoterSnapshot,
     block0_bin: Vec<u8>,
     network_congestion: NetworkCongestion,
     block_account_endpoint_counter: u32,
@@ -58,6 +60,7 @@ impl MockState {
             version: VitVersion {
                 service_version: params.service.version,
             },
+            voters: VoterSnapshot::dummy(),
             block0_bin: jortestkit::file::get_file_as_byte_vec(controller.block0_file())?,
             block_account_endpoint_counter: 0,
         })
@@ -103,6 +106,14 @@ impl MockState {
 
     pub fn vit(&self) -> &Snapshot {
         &self.vit_state
+    }
+
+    pub fn voters(&self) -> &VoterSnapshot {
+        &self.voters
+    }
+
+    pub fn voters_mut(&mut self) -> &mut VoterSnapshot {
+        &mut self.voters
     }
 
     pub fn ledger(&self) -> &LedgerState {

--- a/vitup/src/mode/mock/mod.rs
+++ b/vitup/src/mode/mock/mod.rs
@@ -5,6 +5,7 @@ mod ledger_state;
 mod logger;
 mod mock_state;
 mod rest;
+mod snapshot;
 
 pub use config::{read_config, Configuration, Error as MockConfigError};
 pub use congestion::{NetworkCongestion, NetworkCongestionData, NetworkCongestionMode};

--- a/vitup/src/mode/mock/rest/mod.rs
+++ b/vitup/src/mode/mock/rest/mod.rs
@@ -36,6 +36,7 @@ use vit_servicing_station_lib::db::models::proposals::Proposal;
 use vit_servicing_station_lib::v0::endpoints::proposals::ProposalsByVoteplanIdAndIndex;
 use vit_servicing_station_lib::v0::errors::HandleError;
 use vit_servicing_station_lib::v0::result::HandlerResult;
+use voting_hir::VoterHIR;
 use warp::http::header::{HeaderMap, HeaderValue};
 use warp::hyper::service::make_service_fn;
 use warp::{reject::Reject, Filter, Rejection, Reply};
@@ -265,6 +266,12 @@ pub async fn start_rest_server(context: ContextLock) -> Result<(), Error> {
                 root.and(normal.or(jammed).or(moderate).or(reset)).boxed()
             };
 
+            let snapshot_service = warp::path!("add-snapshot" / String)
+                .and(warp::post())
+                .and(warp::body::json())
+                .and(with_context.clone())
+                .and_then(command_add_snapshot);
+
             root.and(
                 reset
                     .or(availability)
@@ -272,7 +279,8 @@ pub async fn start_rest_server(context: ContextLock) -> Result<(), Error> {
                     .or(fund_id)
                     .or(fragment_strategy)
                     .or(network_strategy)
-                    .or(version),
+                    .or(version)
+                    .or(snapshot_service),
             )
             .boxed()
         };
@@ -429,6 +437,24 @@ pub async fn start_rest_server(context: ContextLock) -> Result<(), Error> {
             })
             .with(warp::reply::with::headers(default_headers.clone()));
 
+        let snapshot = {
+            let root = warp::path!("snapshot" / ..);
+
+            let voting_power = warp::path!(String / String)
+                .and(warp::get())
+                .and(with_context.clone())
+                .and_then(get_voting_power)
+                .boxed();
+
+            let tags = warp::path::end()
+                .and(warp::get())
+                .and(with_context.clone())
+                .and_then(get_tags)
+                .boxed();
+
+            root.and(tags.or(voting_power))
+        };
+
         root.and(
             proposals
                 .or(challenges)
@@ -440,7 +466,8 @@ pub async fn start_rest_server(context: ContextLock) -> Result<(), Error> {
                 .or(account)
                 .or(fragment)
                 .or(votes)
-                .or(message),
+                .or(message)
+                .or(snapshot),
         )
         .boxed()
     };
@@ -954,6 +981,20 @@ pub async fn command_forget(context: ContextLock) -> Result<impl Reply, Rejectio
     Ok(warp::reply())
 }
 
+async fn command_add_snapshot(
+    tag: String,
+    new_snapshot: Vec<VoterHIR>,
+    context: ContextLock,
+) -> Result<impl Reply, Rejection> {
+    context
+        .lock()
+        .unwrap()
+        .state_mut()
+        .voters_mut()
+        .update_tag(tag, new_snapshot);
+    Ok(warp::reply())
+}
+
 pub async fn post_message(
     message: warp::hyper::body::Bytes,
     context: ContextLock,
@@ -1414,4 +1455,32 @@ pub async fn authorize_token(
         return Err(warp::reject::custom(TokenError::UnauthorizedToken));
     }
     Ok(())
+}
+
+async fn get_voting_power(
+    tag: String,
+    key_hex: String,
+    context: Arc<std::sync::Mutex<Context>>,
+) -> Result<impl Reply, Rejection> {
+    let entries = context
+        .lock()
+        .unwrap()
+        .state()
+        .voters()
+        .get_voting_power(&tag, &parse_account_id(&key_hex)?.into())
+        .into_iter()
+        .map(
+            |VoterHIR {
+                 voting_group,
+                 voting_power,
+                 ..
+             }| serde_json::json!({"voting_power": voting_power, "voting_group": voting_group}),
+        )
+        .collect::<Vec<_>>();
+    Ok(warp::reply::json(&entries))
+}
+
+async fn get_tags(context: Arc<std::sync::Mutex<Context>>) -> Result<impl Reply, Rejection> {
+    let entries = context.lock().unwrap().state().voters().tags();
+    Ok(warp::reply::json(&entries))
 }

--- a/vitup/src/mode/mock/snapshot.rs
+++ b/vitup/src/mode/mock/snapshot.rs
@@ -1,0 +1,148 @@
+use jormungandr_lib::crypto::account::Identifier;
+use proptest::{
+    arbitrary::Arbitrary, prelude::*, strategy::BoxedStrategy, test_runner::TestRunner,
+};
+use std::collections::BTreeMap;
+use voting_hir::VoterHIR;
+
+// TODO: this is a temporary impl until the snapshot service is available as a standalone
+// microservice.
+#[derive(Debug)]
+pub struct VoterSnapshot {
+    hirs_by_tag: BTreeMap<String, Vec<VoterHIR>>,
+}
+
+impl VoterSnapshot {
+    pub fn get_voting_power(&self, tag: &str, voting_key: &Identifier) -> Vec<VoterHIR> {
+        self.hirs_by_tag
+            .get(tag)
+            .iter()
+            .flat_map(|hirs| hirs.iter())
+            .filter(|voter| &voter.voting_key == voting_key)
+            .cloned()
+            .collect()
+    }
+
+    pub fn update_tag(&mut self, tag: String, voter_hirs: Vec<VoterHIR>) {
+        self.hirs_by_tag.insert(tag, voter_hirs);
+    }
+
+    pub fn tags(&self) -> Vec<String> {
+        self.hirs_by_tag.keys().cloned().collect()
+    }
+
+    pub fn dummy() -> Self {
+        let mut test_runner = TestRunner::deterministic();
+        Self::arbitrary_with(())
+            .new_tree(&mut test_runner)
+            .unwrap()
+            .current()
+    }
+}
+
+#[derive(Debug)]
+struct ArbitraryVoterHIR(VoterHIR);
+
+impl Arbitrary for ArbitraryVoterHIR {
+    type Parameters = Option<String>;
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+        if let Some(voting_group) = args {
+            any::<([u8; 32], u64)>()
+                .prop_map(move |(key, voting_power)| {
+                    Self(VoterHIR {
+                        voting_key: Identifier::from_hex(&hex::encode(key)).unwrap(),
+                        voting_power: voting_power.into(),
+                        voting_group: voting_group.clone(),
+                    })
+                })
+                .boxed()
+        } else {
+            any::<([u8; 32], u64, String)>()
+                .prop_map(|(key, voting_power, voting_group)| {
+                    Self(VoterHIR {
+                        voting_key: Identifier::from_hex(&hex::encode(key)).unwrap(),
+                        voting_power: voting_power.into(),
+                        voting_group,
+                    })
+                })
+                .boxed()
+        }
+    }
+}
+
+impl Arbitrary for VoterSnapshot {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        let tags = vec![
+            String::from("latest"),
+            String::from("fund8"),
+            String::from("nightly"),
+        ];
+        any_with::<(Vec<ArbitraryVoterHIR>, Vec<ArbitraryVoterHIR>)>((
+            (Default::default(), Some("direct".into())),
+            (Default::default(), Some("dreps".into())),
+        ))
+        .prop_map(move |(dreps, voters)| {
+            let mut hirs_by_tag = BTreeMap::new();
+            let hirs = dreps
+                .into_iter()
+                .map(|x| x.0)
+                .chain(voters.into_iter().map(|x| x.0))
+                .collect::<Vec<_>>();
+            for tag in tags.clone() {
+                hirs_by_tag.insert(tag, hirs.clone());
+            }
+            Self { hirs_by_tag }
+        })
+        .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_voting_power() {
+        let mut hirs = BTreeMap::new();
+        hirs.insert("a".into(), Vec::new());
+        hirs.insert("b".into(), Vec::new());
+        hirs.insert("c".into(), Vec::new());
+
+        let key = [0u8; 32];
+        let vk = Identifier::from_hex(&hex::encode(key)).unwrap();
+
+        let mut snapshot = VoterSnapshot { hirs_by_tag: hirs };
+        assert_eq!(snapshot.get_voting_power("a", &vk), Vec::new());
+        let entries = vec![
+            VoterHIR {
+                voting_key: vk.clone(),
+                voting_power: 1.into(),
+                voting_group: "g".into(),
+            },
+            VoterHIR {
+                voting_key: vk.clone(),
+                voting_power: 1.into(),
+                voting_group: "gg".into(),
+            },
+        ];
+        snapshot.update_tag("a".into(), entries.clone());
+        assert_eq!(snapshot.get_voting_power("a", &vk), entries);
+    }
+
+    #[test]
+    fn test_tags() {
+        let mut hirs = BTreeMap::new();
+        hirs.insert("a".into(), Vec::new());
+        hirs.insert("b".into(), Vec::new());
+        hirs.insert("c".into(), Vec::new());
+        assert_eq!(
+            &[String::from("a"), String::from("b"), String::from("c")],
+            VoterSnapshot { hirs_by_tag: hirs }.tags().as_slice()
+        );
+    }
+}

--- a/vitup/src/mode/mock/snapshot.rs
+++ b/vitup/src/mode/mock/snapshot.rs
@@ -31,6 +31,10 @@ impl VoterSnapshot {
         self.hirs_by_tag.keys().cloned().collect()
     }
 
+    pub fn get_snapshot(&self, tag: &str) -> Vec<VoterHIR> {
+        self.hirs_by_tag.get(tag).cloned().unwrap_or_default()
+    }
+
     pub fn dummy() -> Self {
         let mut test_runner = TestRunner::deterministic();
         Self::arbitrary_with(())


### PR DESCRIPTION
Add 3 endpoints to the mock env:
* `api/v0/snapshot`: return snapshot tags (as in snapshot service)
* `api/v0/snapshot/{tag}/{key}`: return voting power and group for selected key (as in snapshot service)
* `api/v0/snapshot/{tag}`: dump contents of snapshot with selected tag (not present in the snapshot service, but it's useful here to retrieve automatically generated data)