### PR TITLE
Prepare snapshot command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
 [[package]]
 name = "cardano-legacy-address"
 version = "0.1.1"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ba8113bc5096f9827865f42bb05ad8bfcb551bcb"
 dependencies = [
  "cbor_event",
  "cryptoxide 0.4.2",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "chain-addr"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ba8113bc5096f9827865f42bb05ad8bfcb551bcb"
 dependencies = [
  "bech32 0.8.1",
  "chain-core",
@@ -625,7 +625,7 @@ dependencies = [
 [[package]]
 name = "chain-core"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ba8113bc5096f9827865f42bb05ad8bfcb551bcb"
 dependencies = [
  "chain-ser",
 ]
@@ -633,7 +633,7 @@ dependencies = [
 [[package]]
 name = "chain-crypto"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ba8113bc5096f9827865f42bb05ad8bfcb551bcb"
 dependencies = [
  "bech32 0.8.1",
  "cryptoxide 0.4.2",
@@ -655,7 +655,7 @@ dependencies = [
 [[package]]
 name = "chain-evm"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ba8113bc5096f9827865f42bb05ad8bfcb551bcb"
 dependencies = [
  "aurora-bn",
  "blake2",
@@ -679,7 +679,7 @@ dependencies = [
 [[package]]
 name = "chain-impl-mockchain"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ba8113bc5096f9827865f42bb05ad8bfcb551bcb"
 dependencies = [
  "cardano-legacy-address",
  "chain-addr",
@@ -719,7 +719,7 @@ dependencies = [
 [[package]]
 name = "chain-ser"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ba8113bc5096f9827865f42bb05ad8bfcb551bcb"
 dependencies = [
  "thiserror",
 ]
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "chain-storage"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ba8113bc5096f9827865f42bb05ad8bfcb551bcb"
 dependencies = [
  "criterion",
  "data-pile",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "chain-time"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ba8113bc5096f9827865f42bb05ad8bfcb551bcb"
 dependencies = [
  "chain-core",
  "chain-ser",
@@ -752,7 +752,7 @@ dependencies = [
 [[package]]
 name = "chain-vote"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ba8113bc5096f9827865f42bb05ad8bfcb551bcb"
 dependencies = [
  "cfg-if 1.0.0",
  "chain-core",
@@ -2205,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "hersir"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#fe45259f818ade0c74f4e273573e001d633e98e5"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#2d85f8479885fba26c35267448d36f12880270f1"
 dependencies = [
  "assert_fs",
  "chain-addr",
@@ -2550,7 +2550,7 @@ dependencies = [
 [[package]]
 name = "imhamt"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ba8113bc5096f9827865f42bb05ad8bfcb551bcb"
 dependencies = [
  "proptest",
  "rustc_version",
@@ -2721,7 +2721,7 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 [[package]]
 name = "jcli"
 version = "0.13.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#fe45259f818ade0c74f4e273573e001d633e98e5"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#2d85f8479885fba26c35267448d36f12880270f1"
 dependencies = [
  "base64 0.13.0",
  "bech32 0.8.1",
@@ -2764,7 +2764,7 @@ dependencies = [
 [[package]]
 name = "jormungandr-automation"
 version = "0.13.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#fe45259f818ade0c74f4e273573e001d633e98e5"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#2d85f8479885fba26c35267448d36f12880270f1"
 dependencies = [
  "assert_cmd 2.0.4",
  "assert_fs",
@@ -2828,7 +2828,7 @@ dependencies = [
 [[package]]
 name = "jormungandr-integration-tests"
 version = "0.13.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#fe45259f818ade0c74f4e273573e001d633e98e5"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#2d85f8479885fba26c35267448d36f12880270f1"
 dependencies = [
  "assert_cmd 2.0.4",
  "assert_fs",
@@ -2880,7 +2880,7 @@ dependencies = [
 [[package]]
 name = "jormungandr-lib"
 version = "0.13.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#fe45259f818ade0c74f4e273573e001d633e98e5"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#2d85f8479885fba26c35267448d36f12880270f1"
 dependencies = [
  "base64 0.13.0",
  "bech32 0.8.1",
@@ -3111,7 +3111,7 @@ dependencies = [
 [[package]]
 name = "loki"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#fe45259f818ade0c74f4e273573e001d633e98e5"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#2d85f8479885fba26c35267448d36f12880270f1"
 dependencies = [
  "chain-addr",
  "chain-core",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "mjolnir"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#fe45259f818ade0c74f4e273573e001d633e98e5"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#2d85f8479885fba26c35267448d36f12880270f1"
 dependencies = [
  "assert_fs",
  "chain-addr",
@@ -5186,7 +5186,7 @@ dependencies = [
 [[package]]
 name = "sparse-array"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ba8113bc5096f9827865f42bb05ad8bfcb551bcb"
 
 [[package]]
 name = "spin"
@@ -5542,7 +5542,7 @@ dependencies = [
 [[package]]
 name = "thor"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#fe45259f818ade0c74f4e273573e001d633e98e5"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#2d85f8479885fba26c35267448d36f12880270f1"
 dependencies = [
  "assert_fs",
  "bech32 0.8.1",
@@ -6078,7 +6078,7 @@ dependencies = [
 [[package]]
 name = "typed-bytes"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#bbb9552defaf3ea1fa4efcca697bc3edf513095f"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ba8113bc5096f9827865f42bb05ad8bfcb551bcb"
 
 [[package]]
 name = "typenum"

--- a/doc/vitup/configuration.md
+++ b/doc/vitup/configuration.md
@@ -94,19 +94,6 @@ Supported syntax:
 
 ##### random
 
-Amount of wallets which receive specified amount of voting power
-
-Example: 
-
-```
-  {
-    "count": 2,
-    "level": 5000
-  },
-```
-
-##### random
-
 Some number of random allets which receive specified amount of voting power
 
 Example: 

--- a/doc/vitup/configuration.md
+++ b/doc/vitup/configuration.md
@@ -4,8 +4,10 @@ This section describe configuration file which can be passed as argument for or 
 
 ### Initials
 
+#### block0
+
 Allows to provide initial addresses/voters which addresses would be put in block0.
-Supported syntax
+Supported syntax:
 
 ##### above threshold 
 
@@ -83,6 +85,63 @@ Example:
         "address":"ca1qknqa67aflzndy0rvkmxhd3gvccme5637qch53kfh0slzkfgv5nwyq4hxu4",
         "funds":8000     
       },
+```
+
+#### snapshot
+
+Allows to provide initial addresses/voters which addresses would be put in initial snapshot.
+Supported syntax:
+
+##### random
+
+Amount of wallets which receive specified amount of voting power
+
+Example: 
+
+```
+  {
+    "count": 2,
+    "level": 5000
+  },
+```
+
+##### random
+
+Some number of random allets which receive specified amount of voting power
+
+Example: 
+
+```
+  {
+    "count": 2,
+    "level": 5000
+  },
+```
+
+##### external
+
+A single entry with specified voting key and voting power
+
+Example: 
+
+```
+  {
+    "key":"3877098d14e80c62c071a1d82e3df0eb9a6cd339a5f66e9ec338274fdcd9d0f4",
+    "funds":300
+  }
+```
+
+##### named
+
+A single entry with specified alias from block0 and optional voting power. If voting power is not defined it would be taken from block0 section. If vitup cannot find alias it will produce an error
+
+Example: 
+
+```
+  {
+    "name": "darek",
+    "funds": 100
+  },
 ```
 
 ### vote plan
@@ -265,26 +324,44 @@ Controls protocol over which vitup is available for client
 
 ```
 {  
-  "initials": [
-    {
-      "above_threshold": 10,
-      "pin": "1234"
-    },
-    {
-      "name": "alice",
-      "pin": "1234",
-      "funds": 10000
-    },
-    {
-      "name": "bob",
-      "pin": "1234",
-      "funds": 10000
-    },
-    {
-      "zero_funds": 10,
-      "pin": "1234"
+  "initials": {
+    "snapsthot": {
+      tag: "daily",
+      content: [
+        {
+          "count": 2,
+          "funds": "1234"
+        },
+        {
+          "name": "alice",
+        }
+        {
+          "name": "bob",
+          "funds": 10001
+        }
+      ]
     }
-  ],
+    "block0":  [
+      {
+        "above_threshold": 10,
+        "pin": "1234"
+      },
+      {
+        "name": "alice",
+        "pin": "1234",
+        "funds": 10000
+      },
+      {
+        "name": "bob",
+        "pin": "1234",
+        "funds": 10000
+      },
+      {
+        "zero_funds": 10,
+        "pin": "1234"
+      }
+    ]
+  },
   "vote_plan": {
         "vote_time": {
             "vote_start": 13,

--- a/doc/vitup/mock.md
+++ b/doc/vitup/mock.md
@@ -107,6 +107,43 @@ Mock will reset account endpoint unavailability
 curl --location --request POST 'http://{mock_address}/api/control/command/block-account/reset'
 ```
 
+##### Add new voters snapshot for specific tag
+
+Add (or overwrite) voters snapshot for this particular tag
+
+```
+curl --location --request POST 'http://{mock_address}/api/control/command/snapshot/add/{tag}' \
+--header 'Content-Type: application/json' \
+--data-raw '
+  [{"voting_group":"direct","voting_key":"241799302733178aca5c0beaa7a43d054cafa36ca5f929edd46313d49e6a0fd5","voting_power":10131166116863755484},{"voting_group":"dreps","voting_key":"0e3fe9b3e4098759df6f7b44bd9b962a53e4b7b821d50bb72cbcdf1ff7f669f8","voting_power":9327154517439309883}]'
+```
+
+##### Add new voters snapshot for specific tag
+
+Create snapshot json which can be uploaded to mock by using `../snapshot/add` command. See [mock configuration](./configuration.md) for more details. Example:
+
+```
+curl --location --request POST 'http://{mock_address}/api/control/command/snapshot/create' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "tag": "daily",
+    "content": [
+    {
+        "count": 2,
+        "level": 5000
+    },
+    {
+        "name": "darek",
+        "funds": 100
+    },
+    {
+        "key":"318947a91d109da7109feaf4625c0cc4e83fe1636ed19408e43a1dabed4090a3",
+        "funds":300
+    }
+]
+}'
+```
+
 ##### Reset environment
 
 Resets environment data
@@ -115,17 +152,19 @@ Resets environment data
 curl --location --request POST 'http://{mock_address}/api/control/command/reset' \
 --header 'Content-Type: application/json' \
 --data-raw '{ 
-  "initials": [ 
-    { 
-      "above_threshold": 10,
-      "pin": "1234"
-    },
-    {
-      "name": "darek",
-      "pin": "1234",
-      "funds": 10000
-    }
-  ],
+  "initials": {
+    "block0": [
+      { 
+        "above_threshold": 10,
+        "pin": "1234"
+      },
+      {
+        "name": "darek",
+        "pin": "1234",
+        "funds": 10000
+      }
+    ]
+  },
   "vote_plan": {
         "vote_time": {
             "vote_start": 0,
@@ -187,16 +226,4 @@ example:
 
 ```
 vitup-cli --endpoint {mock} disruption control health
-```
-
-
-##### Add new voters snapshot for specific tag
-
-Add (or overwrite) voters snapshot for this particular tag
-
-```
-curl --location --request POST 'http://{mock_address}/api/control/command/add-snapshot/{tag}' \
---header 'Content-Type: application/json' \
---data-raw '
-  [{"voting_group":"direct","voting_key":"241799302733178aca5c0beaa7a43d054cafa36ca5f929edd46313d49e6a0fd5","voting_power":10131166116863755484},{"voting_group":"dreps","voting_key":"0e3fe9b3e4098759df6f7b44bd9b962a53e4b7b821d50bb72cbcdf1ff7f669f8","voting_power":9327154517439309883}]'
 ```

--- a/integration-tests/src/backend/features/batch.rs
+++ b/integration-tests/src/backend/features/batch.rs
@@ -5,7 +5,7 @@ use jormungandr_automation::testing::time;
 use jormungandr_lib::interfaces::FragmentStatus;
 use vit_servicing_station_tests::common::data::ArbitraryValidVotingTemplateGenerator;
 use vitup::config::VoteBlockchainTime;
-use vitup::config::{ConfigBuilder, InitialEntry, Initials};
+use vitup::config::{Block0Initial, Block0Initials, ConfigBuilder};
 use vitup::testing::spawn_network;
 use vitup::testing::vitup_setup;
 const PIN: &str = "1234";
@@ -23,7 +23,7 @@ pub fn transactions_are_send_between_nodes_with_correct_order() {
     };
 
     let config = ConfigBuilder::default()
-        .initials(Initials(vec![InitialEntry::Wallet {
+        .block0_initials(Block0Initials(vec![Block0Initial::Wallet {
             name: ALICE.to_string(),
             funds: 10_000,
             pin: PIN.to_string(),

--- a/integration-tests/src/backend/features/persistent_log.rs
+++ b/integration-tests/src/backend/features/persistent_log.rs
@@ -31,7 +31,7 @@ pub fn persistent_log_contains_all_sent_votes() {
     };
 
     let config = ConfigBuilder::default()
-        .initials_count(no_of_wallets, "1234")
+        .block0_initials_count(no_of_wallets, "1234")
         .slot_duration_in_seconds(2)
         .vote_timing(vote_timing.into())
         .proposals_count(300)

--- a/integration-tests/src/backend/features/update_proposal.rs
+++ b/integration-tests/src/backend/features/update_proposal.rs
@@ -20,7 +20,7 @@ use thor::Wallet;
 use valgrind::Proposal;
 use vit_servicing_station_tests::common::data::ArbitraryValidVotingTemplateGenerator;
 use vitup::config::VoteBlockchainTime;
-use vitup::config::{ConfigBuilder, InitialEntry, Initials};
+use vitup::config::{Block0Initial, Block0Initials, ConfigBuilder};
 use vitup::testing::{spawn_network, vitup_setup};
 
 const PIN: &str = "1234";
@@ -41,14 +41,14 @@ pub fn increase_max_block_content_size_during_voting() {
     };
 
     let config = ConfigBuilder::default()
-        .initials(Initials(vec![
-            InitialEntry::Wallet {
+        .block0_initials(Block0Initials(vec![
+            Block0Initial::Wallet {
                 name: ALICE.to_string(),
                 funds: 10_000,
                 pin: PIN.to_string(),
                 role: Default::default(),
             },
-            InitialEntry::Wallet {
+            Block0Initial::Wallet {
                 name: COMMITTEE.to_string(),
                 funds: 10_000,
                 pin: PIN.to_string(),

--- a/integration-tests/src/backend/features/votes_history.rs
+++ b/integration-tests/src/backend/features/votes_history.rs
@@ -11,7 +11,7 @@ use valgrind::Proposal;
 use vit_servicing_station_lib::v0::endpoints::proposals::ProposalVoteplanIdAndIndexes;
 use vit_servicing_station_tests::common::data::ArbitraryValidVotingTemplateGenerator;
 use vitup::config::VoteBlockchainTime;
-use vitup::config::{ConfigBuilder, InitialEntry, Initials};
+use vitup::config::{Block0Initial, Block0Initials, ConfigBuilder};
 use vitup::testing::{spawn_network, vitup_setup};
 
 const PIN: &str = "1234";
@@ -29,7 +29,7 @@ pub fn votes_history_reflects_casted_votes() {
     };
 
     let config = ConfigBuilder::default()
-        .initials(Initials(vec![InitialEntry::Wallet {
+        .block0_initials(Block0Initials(vec![Block0Initial::Wallet {
             name: ALICE.to_string(),
             funds: 10_000,
             pin: PIN.to_string(),

--- a/integration-tests/src/backend/rewards/active_voters_rewards.rs
+++ b/integration-tests/src/backend/rewards/active_voters_rewards.rs
@@ -10,7 +10,7 @@ use chain_impl_mockchain::block::BlockDate;
 use jormungandr_automation::testing::time;
 use vit_servicing_station_tests::common::data::ArbitraryValidVotingTemplateGenerator;
 use vitup::config::VoteBlockchainTime;
-use vitup::config::{ConfigBuilder, Initials};
+use vitup::config::{Block0Initials, ConfigBuilder};
 use vitup::testing::spawn_network;
 use vitup::testing::vitup_setup;
 
@@ -38,7 +38,7 @@ pub fn voters_with_at_least_one_vote() {
         slots_per_epoch: 30,
     };
     let config = ConfigBuilder::default()
-        .initials(Initials(vec![
+        .block0_initials(Block0Initials(vec![
             alice_wallet.as_initial_entry(),
             bob_wallet.as_initial_entry(),
             clarice_wallet.as_initial_entry(),

--- a/integration-tests/src/backend/rewards/proposers_fund.rs
+++ b/integration-tests/src/backend/rewards/proposers_fund.rs
@@ -5,7 +5,7 @@ use assert_fs::TempDir;
 use vit_servicing_station_tests::common::data::{
     ArbitraryValidVotePlanConfig, ChallengeConfig, ProposalConfig, Snapshot, ValidVotePlanGenerator,
 };
-use vitup::config::{ConfigBuilder, InitialEntry, Initials};
+use vitup::config::{Block0Initial, Block0Initials, ConfigBuilder};
 use vitup::testing::vitup_setup;
 
 #[test]
@@ -49,11 +49,11 @@ pub struct ProposalRewardsTestConfig {
 
 impl ProposalRewardsTestConfig {
     pub fn voter_funds(mut self, voters_funds: &[u64]) -> Self {
-        self.config_builder = self.config_builder.initials(Initials(
+        self.config_builder = self.config_builder.block0_initials(Block0Initials(
             voters_funds
                 .iter()
                 .cloned()
-                .map(InitialEntry::new_random_wallet)
+                .map(Block0Initial::new_random_wallet)
                 .collect(),
         ));
         self

--- a/integration-tests/src/backend/sanity/private.rs
+++ b/integration-tests/src/backend/sanity/private.rs
@@ -13,7 +13,7 @@ use thor::FragmentSender;
 use vit_servicing_station_tests::common::data::ArbitraryValidVotingTemplateGenerator;
 use vitup::config::ConfigBuilder;
 use vitup::config::VoteBlockchainTime;
-use vitup::config::{InitialEntry, Initials};
+use vitup::config::{Block0Initial, Block0Initials};
 use vitup::testing::spawn_network;
 use vitup::testing::vitup_setup;
 
@@ -28,20 +28,20 @@ pub fn private_vote_e2e_flow() -> std::result::Result<(), Error> {
 
     let testing_directory = TempDir::new().unwrap().into_persistent();
     let config = ConfigBuilder::default()
-        .initials(Initials(vec![
-            InitialEntry::Wallet {
+        .block0_initials(Block0Initials(vec![
+            Block0Initial::Wallet {
                 name: "david".to_string(),
                 funds: 10_000,
                 pin: "1234".to_string(),
                 role: Default::default(),
             },
-            InitialEntry::Wallet {
+            Block0Initial::Wallet {
                 name: "edgar".to_string(),
                 funds: 10_000,
                 pin: "1234".to_string(),
                 role: Default::default(),
             },
-            InitialEntry::Wallet {
+            Block0Initial::Wallet {
                 name: "filip".to_string(),
                 funds: 10_000,
                 pin: "1234".to_string(),

--- a/integration-tests/src/backend/sanity/public.rs
+++ b/integration-tests/src/backend/sanity/public.rs
@@ -10,7 +10,7 @@ use thor::FragmentSender;
 use vit_servicing_station_tests::common::data::ArbitraryValidVotingTemplateGenerator;
 use vitup::config::ConfigBuilder;
 use vitup::config::VoteBlockchainTime;
-use vitup::config::{InitialEntry, Initials};
+use vitup::config::{Block0Initial, Block0Initials};
 use vitup::testing::spawn_network;
 use vitup::testing::vitup_setup;
 
@@ -26,20 +26,20 @@ pub fn public_vote_multiple_vote_plans() -> std::result::Result<(), Error> {
     };
     let testing_directory = TempDir::new().unwrap().into_persistent();
     let config = ConfigBuilder::default()
-        .initials(Initials(vec![
-            InitialEntry::Wallet {
+        .block0_initials(Block0Initials(vec![
+            Block0Initial::Wallet {
                 name: "david".to_string(),
                 funds: 10_000,
                 pin: PIN.to_string(),
                 role: Default::default(),
             },
-            InitialEntry::Wallet {
+            Block0Initial::Wallet {
                 name: "edgar".to_string(),
                 funds: 10_000,
                 pin: PIN.to_string(),
                 role: Default::default(),
             },
-            InitialEntry::Wallet {
+            Block0Initial::Wallet {
                 name: "filip".to_string(),
                 funds: 10_000,
                 pin: PIN.to_string(),

--- a/integration-tests/src/common/load.rs
+++ b/integration-tests/src/common/load.rs
@@ -27,7 +27,7 @@ pub fn private_vote_test_scenario(
 ) {
     let testing_directory = TempDir::new().unwrap().into_persistent();
 
-    let wallet_count = config.initials.count();
+    let wallet_count = config.initials.block0.count();
 
     let (mut controller, vit_parameters, network_params) =
         vitup_setup(&config, testing_directory.path().to_path_buf()).unwrap();

--- a/integration-tests/src/common/mainnet.rs
+++ b/integration-tests/src/common/mainnet.rs
@@ -1,7 +1,7 @@
 use catalyst_toolbox::snapshot::registration::{Delegations, VotingRegistration};
 use chain_addr::Discrimination;
 use jormungandr_lib::crypto::account::SigningKey;
-use vitup::config::InitialEntry;
+use vitup::config::Block0Initial;
 
 pub struct MainnetWallet {
     inner: thor::Wallet,
@@ -49,8 +49,8 @@ impl MainnetWallet {
         }
     }
 
-    pub fn as_initial_entry(&self) -> InitialEntry {
-        InitialEntry::External {
+    pub fn as_initial_entry(&self) -> Block0Initial {
+        Block0Initial::External {
             address: self.inner.address().to_string(),
             funds: self.stake,
             role: Default::default(),

--- a/integration-tests/src/e2e/testnet.rs
+++ b/integration-tests/src/e2e/testnet.rs
@@ -10,8 +10,8 @@ use jormungandr_automation::testing::time;
 use snapshot_trigger_service::config::JobParameters;
 use thor::FragmentSender;
 use vit_servicing_station_tests::common::data::ArbitraryValidVotingTemplateGenerator;
+use vitup::config::Block0Initials;
 use vitup::config::ConfigBuilder;
-use vitup::config::Initials;
 use vitup::config::VoteBlockchainTime;
 use vitup::testing::spawn_network;
 use vitup::testing::vitup_setup;
@@ -55,7 +55,7 @@ pub fn e2e_flow_using_voter_registration_local_vitup_and_iapyx() {
         .vote_timing(vote_timing.into())
         .proposals_count(300)
         .voting_power(1)
-        .initials(Initials::new_from_external(
+        .block0_initials(Block0Initials::new_from_external(
             snapshot_result.initials().to_vec(),
         ))
         .private(false)

--- a/integration-tests/src/non_functional/local/load.rs
+++ b/integration-tests/src/non_functional/local/load.rs
@@ -22,7 +22,7 @@ pub fn load_test_public_100_000_votes() {
     };
 
     let config = ConfigBuilder::default()
-        .initials_count(no_of_wallets, "1234")
+        .block0_initials_count(no_of_wallets, "1234")
         .vote_timing(vote_timing.into())
         .slot_duration_in_seconds(2)
         .proposals_count(300)
@@ -91,7 +91,7 @@ pub fn load_test_private_pesimistic() {
     };
 
     let config = ConfigBuilder::default()
-        .initials_count(no_of_wallets, "1234")
+        .block0_initials_count(no_of_wallets, "1234")
         .vote_timing(vote_timing.into())
         .slot_duration_in_seconds(20)
         .proposals_count(250)
@@ -115,7 +115,7 @@ pub fn load_test_private_optimistic() {
     };
 
     let config = ConfigBuilder::default()
-        .initials_count(no_of_wallets, "1234")
+        .block0_initials_count(no_of_wallets, "1234")
         .vote_timing(vote_timing.into())
         .slot_duration_in_seconds(20)
         .proposals_count(500)

--- a/integration-tests/src/non_functional/local/soak.rs
+++ b/integration-tests/src/non_functional/local/soak.rs
@@ -15,7 +15,7 @@ pub fn soak_test_private_super_optimistic() {
     };
 
     let config = ConfigBuilder::default()
-        .initials_count(no_of_wallets, "1234")
+        .block0_initials_count(no_of_wallets, "1234")
         .vote_timing(vote_timing.into())
         .slot_duration_in_seconds(2)
         .proposals_count(500)

--- a/vitup/src/builders/helpers/qr.rs
+++ b/vitup/src/builders/helpers/qr.rs
@@ -48,10 +48,10 @@ pub fn generate_qr_and_hashes<P: AsRef<Path>>(
         wallet.save_qr_code_hash(hash, &pin_to_bytes(pin));
     }
 
-    let zero_funds_initial_counts = parameters.initials.zero_funds_count();
+    let zero_funds_initial_counts = parameters.initials.block0.zero_funds_count();
 
     if zero_funds_initial_counts > 0 {
-        let zero_funds_pin = parameters.initials.zero_funds_pin().unwrap();
+        let zero_funds_pin = parameters.initials.block0.zero_funds_pin().unwrap();
 
         for i in 1..zero_funds_initial_counts + 1 {
             let sk = SecretKey::generate(rand::thread_rng());

--- a/vitup/src/builders/mod.rs
+++ b/vitup/src/builders/mod.rs
@@ -190,13 +190,14 @@ impl VitBackendSettingsBuilder {
         println!("building initials..");
 
         let mut templates = HashMap::new();
-        if self.config.initials.any() {
+        if self.config.initials.block0.any() {
             blockchain = blockchain.with_external_wallets(
                 self.config
                     .initials
+                    .block0
                     .external_templates(token_id.clone().into()),
             );
-            templates = self.config.initials.templates(
+            templates = self.config.initials.block0.templates(
                 self.config.data.voting_power,
                 blockchain.discrimination(),
                 token_id.clone().into(),

--- a/vitup/src/cli/generate/qr.rs
+++ b/vitup/src/cli/generate/qr.rs
@@ -42,7 +42,7 @@ impl QrCommandArgs {
             config_builder = config_builder.initials(initials);
         } else {
             config_builder =
-                config_builder.initials_count(self.initials.unwrap(), &self.global_pin);
+                config_builder.block0_initials_count(self.initials.unwrap(), &self.global_pin);
         }
 
         if !self.output_directory.exists() {

--- a/vitup/src/cli/generate/snapshot.rs
+++ b/vitup/src/cli/generate/snapshot.rs
@@ -1,8 +1,8 @@
 use crate::builders::utils::DeploymentTree;
 use crate::builders::utils::SessionSettingsExtension;
 use crate::builders::VitBackendSettingsBuilder;
+use crate::config::Block0Initials;
 use crate::config::ConfigBuilder;
-use crate::config::Initials;
 use crate::Result;
 use hersir::config::SessionSettings;
 use jormungandr_automation::testing::block0::read_genesis_yaml;
@@ -44,12 +44,12 @@ impl SnapshotCommandArgs {
 
         if let Some(mapping) = self.initials_mapping {
             let content = read_file(mapping)?;
-            let initials: Initials =
+            let initials: Block0Initials =
                 serde_json::from_str(&content).expect("JSON was not well-formatted");
-            config_builder = config_builder.initials(initials);
+            config_builder = config_builder.block0_initials(initials);
         } else {
             config_builder =
-                config_builder.initials_count(self.initials.unwrap(), &self.global_pin);
+                config_builder.block0_initials_count(self.initials.unwrap(), &self.global_pin);
         }
 
         let mut quick_setup = VitBackendSettingsBuilder::default();

--- a/vitup/src/cli/start/advanced.rs
+++ b/vitup/src/cli/start/advanced.rs
@@ -114,6 +114,7 @@ impl AdvancedStartCommandArgs {
         if let Some(snapshot) = self.snapshot {
             config
                 .initials
+                .block0
                 .extend_from_external(read_initials(snapshot)?);
         }
 

--- a/vitup/src/cli/start/quick.rs
+++ b/vitup/src/cli/start/quick.rs
@@ -3,7 +3,7 @@ pub use crate::builders::{VitBackendSettingsBuilder, LEADER_1, LEADER_2, LEADER_
 use crate::config::ConfigBuilder;
 use crate::config::{
     mode::{parse_mode_from_str, Mode},
-    Initials, VoteTime,
+    Block0Initials as Initials, VoteTime,
 };
 use crate::mode::spawn::{spawn_network, NetworkSpawnParams};
 use crate::{error::Error, Result};
@@ -48,7 +48,7 @@ pub struct QuickStartCommandArgs {
     ///   "8000",
     ///   "10000",
     /// }
-    #[structopt(long = "initials-mapping", conflicts_with = "initials")]
+    #[structopt(long = "block-initials-mapping", conflicts_with = "initials")]
     pub initials_mapping: Option<PathBuf>,
 
     /// vote start epoch of vote plan
@@ -156,13 +156,14 @@ impl QuickStartCommandArgs {
             let content = read_file(mapping)?;
             let initials: Initials =
                 serde_json::from_str(&content).expect("JSON was not well-formatted");
-            config_builder = config_builder.initials(initials);
+            config_builder = config_builder.block0_initials(initials);
         } else {
-            config_builder = config_builder.initials_count(self.initials.unwrap_or(10), "1234");
+            config_builder =
+                config_builder.block0_initials_count(self.initials.unwrap_or(10), "1234");
         }
 
         if let Some(snapshot) = self.snapshot {
-            config_builder = config_builder.extend_initials(read_initials(snapshot)?);
+            config_builder = config_builder.extend_block0_initials(read_initials(snapshot)?);
         }
 
         let vote_timestamps = vec![

--- a/vitup/src/config/builder.rs
+++ b/vitup/src/config/builder.rs
@@ -5,6 +5,7 @@ pub use crate::builders::{
     WalletExtension,
 };
 use crate::config::date_format;
+use crate::config::Block0Initials;
 use crate::config::{Config, Initials, VoteTime};
 use chain_impl_mockchain::fee::LinearFee;
 use jormungandr_lib::interfaces::CommitteeIdDef;
@@ -31,17 +32,22 @@ impl ConfigBuilder {
         self
     }
 
+    pub fn block0_initials(mut self, initials: Block0Initials) -> Self {
+        self.config.initials.block0 = initials;
+        self
+    }
+
     pub fn block_content_max_size(mut self, block_content_max_size: u32) -> Self {
         self.config.blockchain.block_content_max_size = block_content_max_size;
         self
     }
 
-    pub fn initials_count(self, initials_count: usize, pin: &str) -> Self {
-        self.initials(Initials::new_above_threshold(initials_count, pin))
+    pub fn block0_initials_count(self, initials_count: usize, pin: &str) -> Self {
+        self.block0_initials(Block0Initials::new_above_threshold(initials_count, pin))
     }
 
-    pub fn extend_initials(mut self, initials: Vec<Initial>) -> Self {
-        self.config.initials.extend_from_external(initials);
+    pub fn extend_block0_initials(mut self, initials: Vec<Initial>) -> Self {
+        self.config.initials.block0.extend_from_external(initials);
         self
     }
 

--- a/vitup/src/config/initials/block0.rs
+++ b/vitup/src/config/initials/block0.rs
@@ -1,3 +1,4 @@
+use crate::config::initials::Role;
 use chain_addr::Discrimination;
 use chain_impl_mockchain::value::Value;
 use fake::faker::name::en::Name;
@@ -65,19 +66,6 @@ impl Initial {
         }
     }
 }
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum Role {
-    Representative,
-    Voter,
-}
-
-impl Default for Role {
-    fn default() -> Self {
-        Role::Voter
-    }
-}
-
 pub const GRACE_VALUE: u64 = 1;
 
 // suppress, because when implementing complier gives error: deriving `Default` on enums is experimental

--- a/vitup/src/config/initials/mod.rs
+++ b/vitup/src/config/initials/mod.rs
@@ -11,7 +11,7 @@ use std::fmt;
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Initials {
     #[serde(default)]
-    pub snapshot: SnapshotInitials,
+    pub snapshot: Option<SnapshotInitials>,
     #[serde(default)]
     pub block0: Block0Initials,
 }
@@ -25,7 +25,7 @@ pub enum Role {
 impl fmt::Display for Role {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Role::Representative => write!(f, "rep"),
+            Role::Representative => write!(f, "dreps"),
             Role::Voter => write!(f, "direct"),
         }
     }

--- a/vitup/src/config/initials/mod.rs
+++ b/vitup/src/config/initials/mod.rs
@@ -1,0 +1,38 @@
+mod block0;
+mod snapshot;
+
+pub use block0::{Initial as Block0Initial, Initials as Block0Initials};
+use serde::{Deserialize, Serialize};
+pub use snapshot::{
+    Error as SnapshotError, Initial as SnapshotInitial, Initials as SnapshotInitials,
+};
+use std::fmt;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Initials {
+    #[serde(default)]
+    pub snapshot: SnapshotInitials,
+    #[serde(default)]
+    pub block0: Block0Initials,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Role {
+    Representative,
+    Voter,
+}
+
+impl fmt::Display for Role {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Role::Representative => write!(f, "rep"),
+            Role::Voter => write!(f, "direct"),
+        }
+    }
+}
+
+impl Default for Role {
+    fn default() -> Self {
+        Role::Voter
+    }
+}

--- a/vitup/src/config/initials/snapshot.rs
+++ b/vitup/src/config/initials/snapshot.rs
@@ -1,0 +1,105 @@
+use crate::config::initials::Role;
+use chain_crypto::PublicKeyFromStrError;
+use chain_impl_mockchain::value::Value;
+use hersir::builder::Wallet as WalletSettings;
+use jormungandr_lib::crypto::account::Identifier;
+use serde::{Deserialize, Serialize};
+use thor::{Wallet, WalletAlias};
+use voting_hir::VoterHIR;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Initials {
+    pub tag: String,
+    pub content: Vec<Initial>,
+}
+
+impl Default for Initials {
+    fn default() -> Self {
+        Self {
+            tag: "".to_string(),
+            content: Vec::new(),
+        }
+    }
+}
+
+impl Initials {
+    pub fn is_empty(&self) -> bool {
+        self.content.is_empty()
+    }
+
+    pub fn as_voters_hirs(
+        &self,
+        defined_wallets: Vec<(&WalletAlias, &WalletSettings)>,
+    ) -> Result<Vec<VoterHIR>, Error> {
+        let mut voter_hirs = Vec::new();
+
+        for initial in self.content.iter() {
+            match initial {
+                Initial::Random { count, level, role } => {
+                    for _ in 0..*count {
+                        voter_hirs.push(VoterHIR {
+                            voting_key: Wallet::default().account_id(),
+                            voting_group: role.to_string(),
+                            voting_power: (*level).into(),
+                        });
+                    }
+                }
+                Initial::Wallet { name, funds, role } => {
+                    let wallet = defined_wallets
+                        .iter()
+                        .cloned()
+                        .find(|(x, _)| *x == name)
+                        .map(|(_, y)| y.clone())
+                        .ok_or_else(|| Error::CannotFindAlias(name.to_string()))?;
+                    voter_hirs.push(VoterHIR {
+                        voting_power: funds
+                            .map(Value)
+                            .unwrap_or_else(|| *wallet.template().value())
+                            .into(),
+                        voting_key: Wallet::from(wallet).account_id(),
+                        voting_group: role.to_string(),
+                    });
+                }
+                Initial::External { key, funds, role } => {
+                    voter_hirs.push(VoterHIR {
+                        voting_key: Identifier::from_hex(key)?,
+                        voting_group: role.to_string(),
+                        voting_power: (*funds).into(),
+                    });
+                }
+            }
+        }
+        Ok(voter_hirs)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Initial {
+    Random {
+        count: usize,
+        level: u64,
+        #[serde(default)]
+        role: Role,
+    },
+    Wallet {
+        name: String,
+        funds: Option<u64>,
+        #[serde(default)]
+        role: Role,
+    },
+    External {
+        key: String,
+        funds: u64,
+        #[serde(default)]
+        role: Role,
+    },
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("cannot find alias '{0}' in snapshot initials")]
+    CannotFindAlias(String),
+    #[error(transparent)]
+    PublicKey(#[from] PublicKeyFromStrError),
+}

--- a/vitup/src/config/initials/snapshot.rs
+++ b/vitup/src/config/initials/snapshot.rs
@@ -23,10 +23,6 @@ impl Default for Initials {
 }
 
 impl Initials {
-    pub fn is_empty(&self) -> bool {
-        self.content.is_empty()
-    }
-
     pub fn as_voters_hirs(
         &self,
         defined_wallets: Vec<(&WalletAlias, &WalletSettings)>,
@@ -48,7 +44,9 @@ impl Initials {
                     let wallet = defined_wallets
                         .iter()
                         .cloned()
-                        .find(|(x, _)| *x == name)
+                        .find(|(x, _)| {
+                            *x.to_lowercase() == format!("wallet_{}", name).to_lowercase()
+                        })
                         .map(|(_, y)| y.clone())
                         .ok_or_else(|| Error::CannotFindAlias(name.to_string()))?;
                     voter_hirs.push(VoterHIR {

--- a/vitup/src/config/mod.rs
+++ b/vitup/src/config/mod.rs
@@ -15,7 +15,9 @@ use crate::config::vote_time::FORMAT;
 pub use blockchain::Blockchain;
 pub use builder::ConfigBuilder;
 pub use certs::CertificatesBuilder;
-pub use initials::{Initial as InitialEntry, Initials};
+pub use initials::{
+    Block0Initial, Block0Initials, Initials, SnapshotError, SnapshotInitial, SnapshotInitials,
+};
 pub use migrations::{Error as MigrationError, MigrationFilesBuilder};
 pub use service::Service;
 pub use static_data::StaticData;
@@ -60,7 +62,9 @@ impl Config {
                 snapshot.to_path_buf(),
             ));
         }
-        self.initials.extend_from_external(read_initials(snapshot)?);
+        self.initials
+            .block0
+            .extend_from_external(read_initials(snapshot)?);
         Ok(())
     }
 

--- a/vitup/src/mode/mock/snapshot.rs
+++ b/vitup/src/mode/mock/snapshot.rs
@@ -1,18 +1,36 @@
+use crate::config::{SnapshotError, SnapshotInitials};
+use hersir::builder::Wallet as WalletSettings;
 use jormungandr_lib::crypto::account::Identifier;
 use proptest::{
     arbitrary::Arbitrary, prelude::*, strategy::BoxedStrategy, test_runner::TestRunner,
 };
 use std::collections::BTreeMap;
+use thor::WalletAlias;
 use voting_hir::VoterHIR;
 
 // TODO: this is a temporary impl until the snapshot service is available as a standalone
 // microservice.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct VoterSnapshot {
     hirs_by_tag: BTreeMap<String, Vec<VoterHIR>>,
 }
 
 impl VoterSnapshot {
+    pub fn from_config_or_default(
+        defined_wallets: Vec<(&WalletAlias, &WalletSettings)>,
+        snapshot_config: &SnapshotInitials,
+    ) -> Result<Self, SnapshotError> {
+        if !snapshot_config.is_empty() {
+            let mut snapshot = Self::default();
+            snapshot.update_tag(
+                snapshot_config.tag.clone(),
+                snapshot_config.as_voters_hirs(defined_wallets)?,
+            );
+            Ok(snapshot)
+        } else {
+            Ok(Self::dummy())
+        }
+    }
     pub fn get_voting_power(&self, tag: &str, voting_key: &Identifier) -> Vec<VoterHIR> {
         self.hirs_by_tag
             .get(tag)

--- a/vitup/src/mode/mock/snapshot.rs
+++ b/vitup/src/mode/mock/snapshot.rs
@@ -18,9 +18,9 @@ pub struct VoterSnapshot {
 impl VoterSnapshot {
     pub fn from_config_or_default(
         defined_wallets: Vec<(&WalletAlias, &WalletSettings)>,
-        snapshot_config: &SnapshotInitials,
+        snapshot_config: &Option<SnapshotInitials>,
     ) -> Result<Self, SnapshotError> {
-        if !snapshot_config.is_empty() {
+        if let Some(snapshot_config) = snapshot_config {
             let mut snapshot = Self::default();
             snapshot.update_tag(
                 snapshot_config.tag.clone(),

--- a/vitup/src/testing.rs
+++ b/vitup/src/testing.rs
@@ -26,7 +26,7 @@ pub fn vitup_setup_default(
     };
 
     let config = ConfigBuilder::default()
-        .initials_count(no_of_wallets, "1234")
+        .block0_initials_count(no_of_wallets, "1234")
         .slot_duration_in_seconds(5)
         .vote_timing(vote_timing.into())
         .proposals_count(100)


### PR DESCRIPTION
Added another command for creating snapshot content from mock already defined wallets. This will help app developers and tester to better prepare test scenario before this change, if they creates alias like "darek" in `initials` part of configuration, then in order to add new snapshot to mock there is a need to convert acquire public key in bytes of given wallet and add construct json out of it. It is still possible, but I've added another way to build snapshot by using /snapshot/create command. It can create snapshot from:
- already defined wallets when resetting mock (with funds override, to create negative scenarios)
- random entries
- external entries - based on voting keys

