### PR TITLE
fix: Expose `/api/v0/node/stats`.

### DIFF
--- a/valgrind/src/bin/valgrind.rs
+++ b/valgrind/src/bin/valgrind.rs
@@ -62,6 +62,11 @@ async fn main() {
             server_stub.http_node_address(),
         ));
 
+        let stats = warp::path!("node" / "stats").and(reverse_proxy_filter(
+            "".to_string(),
+            server_stub.http_node_address(),
+        ));
+
         let vote = warp::path!("vote" / "active" / ..).and(reverse_proxy_filter(
             "".to_string(),
             server_stub.http_node_address(),
@@ -82,6 +87,7 @@ async fn main() {
                 .or(reviews)
                 .or(settings)
                 .or(explorer)
+                .or(stats)
                 .or(vote)
                 .or(block0),
         )


### PR DESCRIPTION
This is a required endpoint to test the voting app locally.